### PR TITLE
BroadcastChannel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 4.0)
 
 find_package(cmake-bare REQUIRED PATHS node_modules/cmake-bare)
+find_package(cmake-fetch REQUIRED PATHS node_modules/cmake-fetch)
 
 project(bare_channel C)
+
+fetch_package("github:holepunchto/libintrusive#01eae7f")
 
 add_bare_module(bare_channel)
 
@@ -10,4 +13,10 @@ target_sources(
   ${bare_channel}
   PRIVATE
     binding.c
+)
+
+target_link_libraries(
+  ${bare_channel}
+  PUBLIC
+    intrusive
 )

--- a/binding.c
+++ b/binding.c
@@ -119,7 +119,11 @@ struct bare_channel_broadcast_s {
 
   intrusive_list_t ports;
 
+  uv_mutex_t lock;
+
   bare_channel_broadcast_message_t buffer[BARE_CHANNEL_BROADCAST_RING_CAPACITY];
+
+  js_deferred_teardown_t *teardown;
 };
 
 static inline bare_channel_message_t *
@@ -853,10 +857,26 @@ bare_channel_port_close(js_env_t *env, js_callback_info_t *info) {
 }
 
 static void
+bare_channel_broadcast__on_teardown(js_deferred_teardown_t *handle, void *data) {
+  int err;
+
+  bare_channel_broadcast_t *channel = data;
+
+  js_deferred_teardown_t *teardown = channel->teardown;
+
+  uv_mutex_destroy(&channel->lock);
+
+  err = js_finish_deferred_teardown_callback(teardown);
+  assert(err == 0);
+}
+
+static void
 bare_channel_broadcast__recycle_queue(js_env_t *env, bare_channel_broadcast_t *channel) {
   int err;
 
   int min_tail = INT_MAX;
+
+  uv_mutex_lock(&channel->lock);
 
   intrusive_list_for_each(next, &channel->ports) {
     bare_channel_broadcast_port_t *port = intrusive_entry(next, bare_channel_broadcast_port_t, node);
@@ -886,29 +906,35 @@ bare_channel_broadcast__recycle_queue(js_env_t *env, bare_channel_broadcast_t *c
   } else {
     atomic_store_explicit(&channel->tail_cursor, curr_tail, memory_order_release);
   }
+
+  uv_mutex_unlock(&channel->lock);
 }
 
 static void
-bare_channel_broadcast__on_close(bare_channel_broadcast_port_t *port) {
+bare_channel_port_broadcast__on_close(bare_channel_broadcast_port_t *port) {
   int err;
 
   port->closing = true;
 
   js_deferred_teardown_t *teardown = port->teardown;
 
+  uv_mutex_lock(&port->channel->lock);
+
   intrusive_list_remove(&port->channel->ports, &port->node);
+
+  uv_mutex_unlock(&port->channel->lock);
 
   err = js_finish_deferred_teardown_callback(teardown);
   assert(err == 0);
 }
 
 static void
-bare_channel_broadcast__on_teardown(js_deferred_teardown_t *handle, void *data) {
+bare_channel_port_broadcast__on_teardown(js_deferred_teardown_t *handle, void *data) {
   bare_channel_broadcast_port_t *port = data;
 
   if (port->closing) return;
 
-  bare_channel_broadcast__on_close(port);
+  bare_channel_port_broadcast__on_close(port);
 }
 
 static js_value_t *
@@ -927,6 +953,9 @@ bare_channel_broadcast_init(js_env_t *env, js_callback_info_t *info) {
 
   intrusive_list_init(&channel->ports);
 
+  err = uv_mutex_init(&channel->lock);
+  assert(err == 0);
+
   for (size_t i = 0; i < BARE_CHANNEL_BROADCAST_RING_CAPACITY; i++) {
     bare_channel_broadcast_message_t *message = &channel->buffer[i];
 
@@ -936,6 +965,9 @@ bare_channel_broadcast_init(js_env_t *env, js_callback_info_t *info) {
   }
 
   channel->buffer_mask = BARE_CHANNEL_BROADCAST_RING_CAPACITY - 1;
+
+  err = js_add_deferred_teardown_callback(env, bare_channel_broadcast__on_teardown, (void *) channel, &channel->teardown);
+  assert(err == 0);
 
   return handle;
 }
@@ -964,6 +996,8 @@ bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
 
   port->channel = channel;
 
+  uv_mutex_lock(&channel->lock);
+
   int id = atomic_fetch_add_explicit(&channel->next, 1, memory_order_acq_rel);
   port->id = id;
 
@@ -972,9 +1006,11 @@ bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
 
   intrusive_list_append(&channel->ports, &port->node);
 
+  uv_mutex_unlock(&channel->lock);
+
   port->closing = false;
 
-  err = js_add_deferred_teardown_callback(env, bare_channel_broadcast__on_teardown, (void *) port, &port->teardown);
+  err = js_add_deferred_teardown_callback(env, bare_channel_port_broadcast__on_teardown, (void *) port, &port->teardown);
   assert(err == 0);
 
   return handle;
@@ -1090,7 +1126,7 @@ bare_channel_port_broadcast_close(js_env_t *env, js_callback_info_t *info) {
   err = js_get_arraybuffer_info(env, argv[0], (void **) &port, NULL);
   assert(err == 0);
 
-  bare_channel_broadcast__on_close(port);
+  bare_channel_port_broadcast__on_close(port);
 
   return NULL;
 }

--- a/binding.c
+++ b/binding.c
@@ -126,6 +126,7 @@ struct bare_channel_broadcast_port_s {
 
 struct bare_channel_broadcast_s {
   atomic_int next;
+
   atomic_int head_cursor;
   atomic_int tail_cursor;
 
@@ -870,96 +871,116 @@ bare_channel_port_close(js_env_t *env, js_callback_info_t *info) {
   return NULL;
 }
 
-static void
-bare_channel_broadcast__on_teardown(js_deferred_teardown_t *handle, void *data) {
-  int err;
+static inline bare_channel_broadcast_message_t *
+bare_channel_port_broadcast__peek_read(bare_channel_broadcast_port_t *port) {
+  bare_channel_broadcast_t *channel = port->channel;
 
-  bare_channel_broadcast_t *channel = data;
+  int tail = port->tail_cursor;
 
-  js_deferred_teardown_t *teardown = channel->teardown;
+  bare_channel_broadcast_message_t *message = &channel->buffer[tail & channel->buffer_mask];
 
-  uv_mutex_destroy(&channel->lock);
+  int sequence = atomic_load_explicit(&message->sequence, memory_order_relaxed);
 
-  err = js_finish_deferred_teardown_callback(teardown);
-  assert(err == 0);
-}
+  int dif = sequence - (tail + 1);
 
-static void
-bare_channel_port_broadcast__on_close(uv_handle_t *handle) {
-  int err;
+  if (dif != 0) {
+    return NULL;
+  }
 
-  bare_channel_broadcast_port_t *port = handle->data;
+  port->tail_cursor++;
 
-  if (--port->state.closing_count != 0) return;
+  if (message->writer_id == port->id) {
+    return bare_channel_port_broadcast__peek_read(port);
+  }
 
-  js_deferred_teardown_t *teardown = port->teardown;
-
-  js_env_t *env = port->env;
-
-  js_handle_scope_t *scope;
-  err = js_open_handle_scope(env, &scope);
-  assert(err == 0);
-
-  js_value_t *ctx;
-  err = js_get_reference_value(env, port->ctx, &ctx);
-  assert(err == 0);
-
-  js_value_t *on_destroy;
-  err = js_get_reference_value(env, port->on_close, &on_destroy);
-  assert(err == 0);
-
-  err = js_delete_reference(env, port->on_drain);
-  assert(err == 0);
-
-  err = js_delete_reference(env, port->on_flush);
-  assert(err == 0);
-
-  err = js_delete_reference(env, port->on_close);
-  assert(err == 0);
-
-  err = js_delete_reference(env, port->ctx);
-  assert(err == 0);
-
-  uv_mutex_lock(&port->channel->lock);
-
-  intrusive_list_remove(&port->channel->ports, &port->node);
-
-  uv_mutex_unlock(&port->channel->lock);
-
-  js_call_function(env, ctx, on_destroy, 0, NULL, NULL);
-
-  err = js_close_handle_scope(env, scope);
-  assert(err == 0);
-
-  err = js_finish_deferred_teardown_callback(teardown);
-  assert(err == 0);
+  return message;
 }
 
 static inline void
-bare_channel_port_broadcast__close(bare_channel_broadcast_port_t *port) {
-  if (port->state.closing) return;
+bare_channel_port_broadcast__after_read(js_env_t *env, bare_channel_broadcast_t *channel) {
+  int err;
 
-  port->state.closing = true;
-  port->state.closing_count = 2;
+  int min_port_tail = INT_MAX;
 
-  uv_close((uv_handle_t *) &port->signals.drain, bare_channel_port_broadcast__on_close);
-  uv_close((uv_handle_t *) &port->signals.flush, bare_channel_port_broadcast__on_close);
+  uv_mutex_lock(&channel->lock);
+
+  intrusive_list_for_each(next, &channel->ports) {
+    bare_channel_broadcast_port_t *port = intrusive_entry(next, bare_channel_broadcast_port_t, node);
+
+    if (port->state.closing) {
+      continue;
+    }
+
+    if (port->tail_cursor < min_port_tail) {
+      min_port_tail = port->tail_cursor;
+    }
+  }
+
+  if (min_port_tail == INT_MAX) {
+    uv_mutex_unlock(&channel->lock);
+
+    return;
+  }
+
+  int channel_tail = atomic_load_explicit(&channel->tail_cursor, memory_order_acquire);
+
+  if (min_port_tail == channel_tail) {
+    uv_mutex_unlock(&channel->lock);
+
+    atomic_store_explicit(&channel->tail_cursor, channel_tail, memory_order_release);
+
+    return;
+  }
+
+  for (int i = channel_tail; i < min_port_tail; i++) {
+    bare_channel_broadcast_message_t *message = &channel->buffer[i & channel->buffer_mask];
+
+    int sequence = atomic_load_explicit(&message->sequence, memory_order_acquire);
+
+    message->writer_id = -1;
+
+    err = js_release_arraybuffer_backing_store(env, message->backing_store);
+    assert(err == 0);
+
+    atomic_store_explicit(&message->sequence, sequence + channel->buffer_mask, memory_order_release);
+  }
+
+  atomic_store_explicit(&channel->tail_cursor, min_port_tail, memory_order_release);
+
+  intrusive_list_for_each(next, &channel->ports) {
+    bare_channel_broadcast_port_t *port = intrusive_entry(next, bare_channel_broadcast_port_t, node);
+
+    err = uv_async_send(&port->signals.drain);
+    assert(err == 0);
+  }
+
+  uv_mutex_unlock(&channel->lock);
 }
 
-static void
-bare_channel_port_broadcast__on_teardown(js_deferred_teardown_t *handle, void *data) {
-  bare_channel_broadcast_port_t *port = data;
+static inline void
+bare_channel_port_broadcast__after_write(bare_channel_broadcast_t *channel) {
+  int err;
 
-  bare_channel_port_broadcast__close(port);
+  uv_mutex_lock(&channel->lock);
+
+  intrusive_list_for_each(next, &channel->ports) {
+    bare_channel_broadcast_port_t *port = intrusive_entry(next, bare_channel_broadcast_port_t, node);
+
+    err = uv_async_send(&port->signals.flush);
+    assert(err == 0);
+  }
+
+  uv_mutex_unlock(&channel->lock);
 }
+
+static inline void
+bare_channel_port_broadcast__close(bare_channel_broadcast_port_t *port);
 
 static void
 bare_channel_port_broadcast__on_drain(uv_async_t *handle) {
   int err;
 
   bare_channel_broadcast_port_t *port = handle->data;
-
-  if (port->state.closing) return;
 
   js_env_t *env = port->env;
 
@@ -987,8 +1008,6 @@ bare_channel_port_broadcast__on_flush(uv_async_t *handle) {
 
   bare_channel_broadcast_port_t *port = handle->data;
 
-  if (port->state.closing) return;
-
   js_env_t *env = port->env;
 
   js_handle_scope_t *scope;
@@ -1010,85 +1029,77 @@ bare_channel_port_broadcast__on_flush(uv_async_t *handle) {
 }
 
 static void
-bare_channel_port_broadcast__on_read(bare_channel_broadcast_port_t *reader) {
+bare_channel_port_broadcast__on_close(uv_handle_t *handle) {
   int err;
 
-  uv_mutex_lock(&reader->channel->lock);
+  bare_channel_broadcast_port_t *port = handle->data;
 
-  intrusive_list_for_each(next, &reader->channel->ports) {
-    bare_channel_broadcast_port_t *port = intrusive_entry(next, bare_channel_broadcast_port_t, node);
+  if (--port->state.closing_count != 0) return;
 
-    if (port->state.closing || port->id == reader->id) {
-      continue;
-    }
+  js_deferred_teardown_t *teardown = port->teardown;
 
-    err = uv_async_send(&port->signals.drain);
-    assert(err == 0);
-  }
+  js_env_t *env = port->env;
 
-  uv_mutex_unlock(&reader->channel->lock);
-}
-
-static void
-bare_channel_port_broadcast__on_write(bare_channel_broadcast_port_t *writer) {
-  int err;
-
-  uv_mutex_lock(&writer->channel->lock);
-
-  intrusive_list_for_each(next, &writer->channel->ports) {
-    bare_channel_broadcast_port_t *port = intrusive_entry(next, bare_channel_broadcast_port_t, node);
-
-    if (port->state.closing || port->id == writer->id) {
-      continue;
-    }
-
-    err = uv_async_send(&port->signals.flush);
-    assert(err == 0);
-  }
-
-  uv_mutex_unlock(&writer->channel->lock);
-}
-
-static bool
-bare_channel_broadcast__recycle_queue(js_env_t *env, bare_channel_broadcast_t *channel) {
-  int err;
-
-  int min_tail = INT_MAX;
+  bare_channel_broadcast_t *channel = port->channel;
 
   uv_mutex_lock(&channel->lock);
 
-  intrusive_list_for_each(next, &channel->ports) {
-    bare_channel_broadcast_port_t *port = intrusive_entry(next, bare_channel_broadcast_port_t, node);
-
-    if (port->tail_cursor < min_tail) {
-      min_tail = port->tail_cursor;
-    }
-  }
+  intrusive_list_remove(&channel->ports, &port->node);
 
   uv_mutex_unlock(&channel->lock);
 
-  int curr_tail = atomic_load_explicit(&channel->tail_cursor, memory_order_acquire);
+  js_handle_scope_t *scope;
+  err = js_open_handle_scope(env, &scope);
+  assert(err == 0);
 
-  if (min_tail > curr_tail) {
-    for (int i = curr_tail; i < min_tail; i++) {
-      bare_channel_broadcast_message_t *message = &channel->buffer[i & channel->buffer_mask];
+  js_value_t *ctx;
+  err = js_get_reference_value(env, port->ctx, &ctx);
+  assert(err == 0);
 
-      int sequence = atomic_load_explicit(&message->sequence, memory_order_acquire);
+  js_value_t *on_destroy;
+  err = js_get_reference_value(env, port->on_close, &on_destroy);
+  assert(err == 0);
 
-      err = js_release_arraybuffer_backing_store(env, message->backing_store);
-      assert(err == 0);
+  err = js_delete_reference(env, port->on_drain);
+  assert(err == 0);
 
-      message->writer_id = -1;
+  err = js_delete_reference(env, port->on_flush);
+  assert(err == 0);
 
-      atomic_store_explicit(&message->sequence, sequence + channel->buffer_mask, memory_order_release);
-    }
+  err = js_delete_reference(env, port->on_close);
+  assert(err == 0);
 
-    atomic_store_explicit(&channel->tail_cursor, min_tail, memory_order_release);
-  } else {
-    atomic_store_explicit(&channel->tail_cursor, curr_tail, memory_order_release);
-  }
+  err = js_delete_reference(env, port->ctx);
+  assert(err == 0);
 
-  return min_tail > curr_tail;
+  js_call_function(env, ctx, on_destroy, 0, NULL, NULL);
+
+  err = js_close_handle_scope(env, scope);
+  assert(err == 0);
+
+  err = js_finish_deferred_teardown_callback(teardown);
+  assert(err == 0);
+}
+
+static void
+bare_channel_port_broadcast__on_teardown(js_deferred_teardown_t *handle, void *data) {
+  bare_channel_broadcast_port_t *port = data;
+
+  bare_channel_port_broadcast__close(port);
+}
+
+static void
+bare_channel_broadcast__on_teardown(js_deferred_teardown_t *handle, void *data) {
+  int err;
+
+  bare_channel_broadcast_t *channel = data;
+
+  js_deferred_teardown_t *teardown = channel->teardown;
+
+  uv_mutex_destroy(&channel->lock);
+
+  err = js_finish_deferred_teardown_callback(teardown);
+  assert(err == 0);
 }
 
 static js_value_t *
@@ -1102,8 +1113,11 @@ bare_channel_broadcast_init(js_env_t *env, js_callback_info_t *info) {
   assert(err == 0);
 
   atomic_init(&channel->next, 0);
+
   atomic_init(&channel->head_cursor, 0);
   atomic_init(&channel->tail_cursor, 0);
+
+  channel->buffer_mask = BARE_CHANNEL_BROADCAST_RING_CAPACITY - 1;
 
   intrusive_list_init(&channel->ports);
 
@@ -1117,8 +1131,6 @@ bare_channel_broadcast_init(js_env_t *env, js_callback_info_t *info) {
 
     atomic_init(&message->sequence, i);
   }
-
-  channel->buffer_mask = BARE_CHANNEL_BROADCAST_RING_CAPACITY - 1;
 
   err = js_add_deferred_teardown_callback(env, bare_channel_broadcast__on_teardown, (void *) channel, &channel->teardown);
   assert(err == 0);
@@ -1154,6 +1166,19 @@ bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
 
   port->channel = channel;
 
+  int id = atomic_fetch_add_explicit(&channel->next, 1, memory_order_acq_rel);
+  port->id = id;
+
+  int initial_tail = atomic_load_explicit(&channel->tail_cursor, memory_order_relaxed);
+  port->tail_cursor = initial_tail;
+
+  uv_mutex_lock(&channel->lock);
+  intrusive_list_append(&channel->ports, &port->node);
+  uv_mutex_unlock(&channel->lock);
+
+  port->state.closing = false;
+  port->state.closing_count = 0;
+
   port->env = env;
 
   err = js_create_reference(env, argv[1], 1, &port->ctx);
@@ -1168,21 +1193,6 @@ bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
   err = js_create_reference(env, argv[4], 1, &port->on_close);
   assert(err == 0);
 
-  uv_mutex_lock(&channel->lock);
-
-  int id = atomic_fetch_add_explicit(&channel->next, 1, memory_order_acq_rel);
-  port->id = id;
-
-  int initial_tail = atomic_load_explicit(&channel->tail_cursor, memory_order_relaxed);
-  port->tail_cursor = initial_tail;
-
-  intrusive_list_append(&channel->ports, &port->node);
-
-  uv_mutex_unlock(&channel->lock);
-
-  port->state.closing = false;
-  port->state.closing_count = 0;
-
   err = js_add_deferred_teardown_callback(env, bare_channel_port_broadcast__on_teardown, (void *) port, &port->teardown);
   assert(err == 0);
 
@@ -1194,47 +1204,7 @@ bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
   V(flush)
 #undef V
 
-  err = uv_async_send(&port->signals.flush);
-  assert(err == 0);
-
   return handle;
-}
-
-static js_value_t *
-bare_channel_port_broadcast__read(js_env_t *env, bare_channel_broadcast_port_t *port) {
-  int err;
-
-  bare_channel_broadcast_t *channel = port->channel;
-
-  int tail = port->tail_cursor;
-
-  bare_channel_broadcast_message_t *message = &channel->buffer[tail & channel->buffer_mask];
-
-  int sequence = atomic_load_explicit(&message->sequence, memory_order_relaxed);
-
-  int dif = sequence - (tail + 1);
-
-  if (dif == 0 && message->writer_id == port->id) {
-    port->tail_cursor++;
-
-    return bare_channel_port_broadcast__read(env, port);
-  }
-
-  js_value_t *result;
-
-  if (dif == 0) {
-    port->tail_cursor++;
-
-    err = js_create_arraybuffer_with_backing_store(env, message->backing_store, NULL, NULL, &result);
-    assert(err == 0);
-
-    bare_channel_port_broadcast__on_read(port);
-  } else {
-    err = js_get_null(env, &result);
-    assert(err == 0);
-  }
-
-  return result;
 }
 
 static js_value_t *
@@ -1253,42 +1223,23 @@ bare_channel_port_broadcast_read(js_env_t *env, js_callback_info_t *info) {
   err = js_get_arraybuffer_info(env, argv[0], (void **) &port, NULL);
   assert(err == 0);
 
-  return bare_channel_port_broadcast__read(env, port);
-}
-
-static int
-bare_channel_port_broadcast__write(js_env_t *env, bare_channel_broadcast_port_t *port, js_value_t *payload) {
-  int err;
-
   bare_channel_broadcast_t *channel = port->channel;
 
-  int head = atomic_load_explicit(&channel->head_cursor, memory_order_acquire);
+  bare_channel_broadcast_message_t *message = bare_channel_port_broadcast__peek_read(port);
 
-  bare_channel_broadcast_message_t *message = &channel->buffer[head & channel->buffer_mask];
+  js_value_t *result;
 
-  int sequence = atomic_load_explicit(&message->sequence, memory_order_acquire);
-
-  int dif = sequence - head;
-
-  if (dif == 0) {
-    err = js_get_arraybuffer_backing_store(env, payload, &message->backing_store);
+  if (message) {
+    err = js_create_arraybuffer_with_backing_store(env, message->backing_store, NULL, NULL, &result);
     assert(err == 0);
 
-    err = js_detach_arraybuffer(env, payload);
-    assert(err == 0);
-
-    message->writer_id = port->id;
-
-    atomic_store_explicit(&channel->head_cursor, head + 1, memory_order_release);
-    atomic_store_explicit(&message->sequence, sequence + 1, memory_order_release);
-
-    bare_channel_port_broadcast__on_write(port);
+    bare_channel_port_broadcast__after_read(env, channel);
   } else {
-    atomic_store_explicit(&channel->head_cursor, head, memory_order_release);
-    atomic_store_explicit(&message->sequence, sequence, memory_order_release);
+    err = js_get_null(env, &result);
+    assert(err == 0);
   }
 
-  return dif;
+  return result;
 }
 
 static js_value_t *
@@ -1307,12 +1258,32 @@ bare_channel_port_broadcast_write(js_env_t *env, js_callback_info_t *info) {
   err = js_get_arraybuffer_info(env, argv[0], (void **) &port, NULL);
   assert(err == 0);
 
-  int dif = bare_channel_port_broadcast__write(env, port, argv[1]);
+  bare_channel_broadcast_t *channel = port->channel;
 
-  if (dif < 0) {
-    if (bare_channel_broadcast__recycle_queue(env, port->channel)) {
-      dif = bare_channel_port_broadcast__write(env, port, argv[1]);
-    }
+  int head = atomic_load_explicit(&channel->head_cursor, memory_order_acquire);
+
+  bare_channel_broadcast_message_t *message = &channel->buffer[head & channel->buffer_mask];
+
+  int sequence = atomic_load_explicit(&message->sequence, memory_order_acquire);
+
+  int dif = sequence - head;
+
+  if (dif == 0) {
+    message->writer_id = port->id;
+
+    err = js_get_arraybuffer_backing_store(env, argv[1], &message->backing_store);
+    assert(err == 0);
+
+    err = js_detach_arraybuffer(env, argv[1]);
+    assert(err == 0);
+
+    atomic_store_explicit(&channel->head_cursor, head + 1, memory_order_release);
+    atomic_store_explicit(&message->sequence, sequence + 1, memory_order_release);
+
+    bare_channel_port_broadcast__after_write(channel);
+  } else {
+    atomic_store_explicit(&channel->head_cursor, head, memory_order_release);
+    atomic_store_explicit(&message->sequence, sequence, memory_order_release);
   }
 
   js_value_t *result;
@@ -1320,6 +1291,22 @@ bare_channel_port_broadcast_write(js_env_t *env, js_callback_info_t *info) {
   assert(err == 0);
 
   return result;
+}
+
+static inline void
+bare_channel_port_broadcast__close(bare_channel_broadcast_port_t *port) {
+  if (port->state.closing) return;
+
+  port->state.closing = true;
+  port->state.closing_count = 2;
+
+  bare_channel_port_broadcast__after_read(port->env, port->channel);
+
+#define V(signal) \
+  uv_close((uv_handle_t *) &port->signals.signal, bare_channel_port_broadcast__on_close);
+  V(drain)
+  V(flush)
+#undef V
 }
 
 static js_value_t *

--- a/binding.c
+++ b/binding.c
@@ -101,7 +101,7 @@ struct bare_channel_broadcast_port_s {
 
   uint8_t id;
 
-  int tail_cursor;
+  atomic_int tail_cursor;
 
   intrusive_list_node_t node;
 
@@ -875,7 +875,7 @@ static inline bare_channel_broadcast_message_t *
 bare_channel_port_broadcast__peek_read(bare_channel_broadcast_port_t *port) {
   bare_channel_broadcast_t *channel = port->channel;
 
-  int tail = port->tail_cursor;
+  int tail = atomic_load_explicit(&port->tail_cursor, memory_order_acquire);
 
   bare_channel_broadcast_message_t *message = &channel->buffer[tail & channel->buffer_mask];
 
@@ -884,10 +884,12 @@ bare_channel_port_broadcast__peek_read(bare_channel_broadcast_port_t *port) {
   int dif = sequence - (tail + 1);
 
   if (dif != 0) {
+    atomic_store_explicit(&port->tail_cursor, tail, memory_order_release);
+
     return NULL;
   }
 
-  port->tail_cursor++;
+  atomic_store_explicit(&port->tail_cursor, tail + 1, memory_order_release);
 
   if (message->writer_id == port->id) {
     return bare_channel_port_broadcast__peek_read(port);
@@ -911,9 +913,8 @@ bare_channel_port_broadcast__after_read(js_env_t *env, bare_channel_broadcast_t 
     bool closing = atomic_load_explicit(&port->state.closing, memory_order_relaxed);
     if (closing) continue;
 
-    if (port->tail_cursor < min_port_tail) {
-      min_port_tail = port->tail_cursor;
-    }
+    int port_tail = atomic_load_explicit(&port->tail_cursor, memory_order_relaxed);
+    if (port_tail < min_port_tail) min_port_tail = port_tail;
   }
 
   // Handle the 'no active ports' edge-case
@@ -1175,7 +1176,7 @@ bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
   port->id = id;
 
   int initial_tail = atomic_load_explicit(&channel->tail_cursor, memory_order_relaxed);
-  port->tail_cursor = initial_tail;
+  atomic_init(&port->tail_cursor, initial_tail);
 
   uv_mutex_lock(&channel->lock);
 

--- a/binding.c
+++ b/binding.c
@@ -888,22 +888,6 @@ bare_channel_broadcast__recycle_queue(js_env_t *env, bare_channel_broadcast_t *c
   }
 }
 
-static bare_channel_broadcast_port_t *
-bare_channel_broadcast__get_port(bare_channel_broadcast_t *channel, int id) {
-  bare_channel_broadcast_port_t *port = NULL;
-
-  intrusive_list_for_each(next, &channel->ports) {
-    bare_channel_broadcast_port_t *entry = intrusive_entry(next, bare_channel_broadcast_port_t, node);
-
-    if (entry->id == id) {
-      port = entry;
-      break;
-    }
-  }
-
-  return port;
-}
-
 static void
 bare_channel_broadcast__on_close(bare_channel_broadcast_port_t *port) {
   int err;
@@ -913,8 +897,6 @@ bare_channel_broadcast__on_close(bare_channel_broadcast_port_t *port) {
   js_deferred_teardown_t *teardown = port->teardown;
 
   intrusive_list_remove(&port->channel->ports, &port->node);
-
-  free(port);
 
   err = js_finish_deferred_teardown_callback(teardown);
   assert(err == 0);
@@ -974,7 +956,11 @@ bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
   err = js_get_sharedarraybuffer_info(env, argv[0], (void **) &channel, NULL);
   assert(err == 0);
 
-  bare_channel_broadcast_port_t *port = malloc(sizeof(bare_channel_broadcast_port_t));
+  js_value_t *handle;
+
+  bare_channel_broadcast_port_t *port;
+  err = js_create_arraybuffer(env, sizeof(bare_channel_broadcast_port_t), (void **) &port, &handle);
+  assert(err == 0);
 
   port->channel = channel;
 
@@ -991,35 +977,26 @@ bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
   err = js_add_deferred_teardown_callback(env, bare_channel_broadcast__on_teardown, (void *) port, &port->teardown);
   assert(err == 0);
 
-  js_value_t *result;
-  err = js_create_int32(env, id, &result);
-  assert(err == 0);
-
-  return result;
+  return handle;
 }
 
 static js_value_t *
 bare_channel_port_broadcast_read(js_env_t *env, js_callback_info_t *info) {
   int err;
 
-  size_t argc = 2;
-  js_value_t *argv[2];
+  size_t argc = 1;
+  js_value_t *argv[1];
 
   err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
   assert(err == 0);
 
-  assert(argc == 2);
+  assert(argc == 1);
 
-  bare_channel_broadcast_t *channel;
-  err = js_get_sharedarraybuffer_info(env, argv[0], (void **) &channel, NULL);
+  bare_channel_broadcast_port_t *port;
+  err = js_get_arraybuffer_info(env, argv[0], (void **) &port, NULL);
   assert(err == 0);
 
-  int id;
-  err = js_get_value_int32(env, argv[1], &id);
-  assert(err == 0);
-
-  bare_channel_broadcast_port_t *port = bare_channel_broadcast__get_port(channel, id);
-  if (port == NULL) return NULL;
+  bare_channel_broadcast_t *channel = port->channel;
 
   int tail = port->tail_cursor;
 
@@ -1050,24 +1027,19 @@ static js_value_t *
 bare_channel_port_broadcast_write(js_env_t *env, js_callback_info_t *info) {
   int err;
 
-  size_t argc = 3;
-  js_value_t *argv[3];
+  size_t argc = 2;
+  js_value_t *argv[2];
 
   err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
   assert(err == 0);
 
-  assert(argc == 3);
+  assert(argc == 2);
 
-  bare_channel_broadcast_t *channel;
-  err = js_get_sharedarraybuffer_info(env, argv[0], (void **) &channel, NULL);
+  bare_channel_broadcast_port_t *port;
+  err = js_get_arraybuffer_info(env, argv[0], (void **) &port, NULL);
   assert(err == 0);
 
-  int id;
-  err = js_get_value_int32(env, argv[1], &id);
-  assert(err == 0);
-
-  bare_channel_broadcast_port_t *port = bare_channel_broadcast__get_port(channel, id);
-  if (port == NULL) return NULL;
+  bare_channel_broadcast_t *channel = port->channel;
 
   int head = atomic_load_explicit(&channel->head_cursor, memory_order_acquire);
 
@@ -1078,13 +1050,13 @@ bare_channel_port_broadcast_write(js_env_t *env, js_callback_info_t *info) {
   int dif = sequence - head;
 
   if (dif == 0) {
-    err = js_get_arraybuffer_backing_store(env, argv[2], &message->backing_store);
+    err = js_get_arraybuffer_backing_store(env, argv[1], &message->backing_store);
     assert(err == 0);
 
-    err = js_detach_arraybuffer(env, argv[2]);
+    err = js_detach_arraybuffer(env, argv[1]);
     assert(err == 0);
 
-    message->writer_id = id;
+    message->writer_id = port->id;
 
     atomic_store_explicit(&channel->head_cursor, head + 1, memory_order_release);
     atomic_store_explicit(&message->sequence, sequence + 1, memory_order_release);
@@ -1106,27 +1078,19 @@ static js_value_t *
 bare_channel_port_broadcast_close(js_env_t *env, js_callback_info_t *info) {
   int err;
 
-  size_t argc = 2;
-  js_value_t *argv[2];
+  size_t argc = 1;
+  js_value_t *argv[1];
 
   err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
   assert(err == 0);
 
-  assert(argc == 2);
+  assert(argc == 1);
 
-  bare_channel_broadcast_t *channel;
-  err = js_get_sharedarraybuffer_info(env, argv[0], (void **) &channel, NULL);
+  bare_channel_broadcast_port_t *port;
+  err = js_get_arraybuffer_info(env, argv[0], (void **) &port, NULL);
   assert(err == 0);
 
-  int id;
-  err = js_get_value_int32(env, argv[1], &id);
-  assert(err == 0);
-
-  bare_channel_broadcast_port_t *port = bare_channel_broadcast__get_port(channel, id);
-
-  if (port != NULL) {
-    bare_channel_broadcast__on_close(port);
-  }
+  bare_channel_broadcast__on_close(port);
 
   return NULL;
 }

--- a/binding.c
+++ b/binding.c
@@ -900,6 +900,7 @@ static inline void
 bare_channel_port_broadcast__after_read(js_env_t *env, bare_channel_broadcast_t *channel) {
   int err;
 
+  // Calculate the smallest tail from all active ports
   int min_port_tail = INT_MAX;
 
   uv_mutex_lock(&channel->lock);
@@ -916,6 +917,7 @@ bare_channel_port_broadcast__after_read(js_env_t *env, bare_channel_broadcast_t 
     }
   }
 
+  // Handle the 'no active ports' edge-case
   if (min_port_tail == INT_MAX) {
     uv_mutex_unlock(&channel->lock);
 
@@ -924,6 +926,8 @@ bare_channel_port_broadcast__after_read(js_env_t *env, bare_channel_broadcast_t 
 
   int channel_tail = atomic_load_explicit(&channel->tail_cursor, memory_order_acquire);
 
+  // No slots to release
+  // "min_port_tail < channel_tail" should be an impossible case
   if (min_port_tail == channel_tail) {
     uv_mutex_unlock(&channel->lock);
 
@@ -932,6 +936,7 @@ bare_channel_port_broadcast__after_read(js_env_t *env, bare_channel_broadcast_t 
     return;
   }
 
+  // Release slots read by all active ports
   for (int i = channel_tail; i < min_port_tail; i++) {
     bare_channel_broadcast_message_t *message = &channel->buffer[i & channel->buffer_mask];
 
@@ -947,6 +952,7 @@ bare_channel_port_broadcast__after_read(js_env_t *env, bare_channel_broadcast_t 
 
   atomic_store_explicit(&channel->tail_cursor, min_port_tail, memory_order_release);
 
+  // Notify ports that may have pending writes
   intrusive_list_for_each(next, &channel->ports) {
     bare_channel_broadcast_port_t *port = intrusive_entry(next, bare_channel_broadcast_port_t, node);
 
@@ -1173,7 +1179,9 @@ bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
   port->tail_cursor = initial_tail;
 
   uv_mutex_lock(&channel->lock);
+
   intrusive_list_append(&channel->ports, &port->node);
+
   uv_mutex_unlock(&channel->lock);
 
   port->state.closing = false;

--- a/binding.c
+++ b/binding.c
@@ -1238,7 +1238,8 @@ bare_channel_port_broadcast_read(js_env_t *env, js_callback_info_t *info) {
   js_value_t *result;
 
   if (message) {
-    err = js_create_arraybuffer_with_backing_store(env, message->backing_store, NULL, NULL, &result);
+    js_value_t *sharedarraybuffer;
+    err = js_create_sharedarraybuffer_with_backing_store(env, message->backing_store, (void **) &result, NULL, &sharedarraybuffer);
     assert(err == 0);
 
     bare_channel_port_broadcast__after_read(env, channel);
@@ -1279,10 +1280,11 @@ bare_channel_port_broadcast_write(js_env_t *env, js_callback_info_t *info) {
   if (dif == 0) {
     message->writer_id = port->id;
 
-    err = js_get_arraybuffer_backing_store(env, argv[1], &message->backing_store);
+    js_value_t *sharedarraybuffer;
+    err = js_create_sharedarraybuffer(env, sizeof(js_value_t *), (void **) &argv[1], &sharedarraybuffer);
     assert(err == 0);
 
-    err = js_detach_arraybuffer(env, argv[1]);
+    err = js_get_sharedarraybuffer_backing_store(env, sharedarraybuffer, &message->backing_store);
     assert(err == 0);
 
     atomic_store_explicit(&channel->head_cursor, head + 1, memory_order_release);

--- a/binding.c
+++ b/binding.c
@@ -878,6 +878,8 @@ bare_channel_broadcast__recycle_queue(js_env_t *env, bare_channel_broadcast_t *c
       err = js_release_arraybuffer_backing_store(env, message->backing_store);
       assert(err == 0);
 
+      message->writer_id = -1;
+
       atomic_store_explicit(&message->sequence, sequence + channel->buffer_mask, memory_order_release);
     }
 
@@ -1011,11 +1013,13 @@ bare_channel_port_broadcast_read(js_env_t *env, js_callback_info_t *info) {
 
   int dif = sequence - (tail + 1);
 
-  js_value_t *result;
-
   if (dif == 0) {
     port->tail_cursor++;
+  }
 
+  js_value_t *result;
+
+  if (dif == 0 && message->writer_id != port->id) {
     err = js_create_arraybuffer_with_backing_store(env, message->backing_store, NULL, NULL, &result);
     assert(err == 0);
   } else {
@@ -1063,6 +1067,8 @@ bare_channel_port_broadcast_write(js_env_t *env, js_callback_info_t *info) {
 
     err = js_detach_arraybuffer(env, argv[2]);
     assert(err == 0);
+
+    message->writer_id = id;
 
     atomic_store_explicit(&channel->head_cursor, head + 1, memory_order_release);
     atomic_store_explicit(&message->sequence, sequence + 1, memory_order_release);

--- a/binding.c
+++ b/binding.c
@@ -97,11 +97,18 @@ struct bare_channel_broadcast_message_s {
 };
 
 struct bare_channel_broadcast_port_s {
+  bare_channel_broadcast_t *channel;
+
   uint8_t id;
 
   int tail_cursor;
 
   intrusive_list_node_t node;
+
+  struct {
+    bool closing;
+    bool exiting;
+  } state;
 };
 
 struct bare_channel_broadcast_s {
@@ -863,7 +870,7 @@ bare_channel_broadcast__recycle_queue(js_env_t *env, bare_channel_broadcast_t *c
   int curr_tail = atomic_load_explicit(&channel->tail_cursor, memory_order_acquire);
 
   if (min_tail > curr_tail) {
-    for (int i = channel->tail_cursor; i <= min_tail; i++) {
+    for (int i = channel->tail_cursor; i < min_tail; i++) {
       bare_channel_broadcast_message_t *message = &channel->buffer[i & channel->buffer_mask];
 
       int sequence = atomic_load_explicit(&message->sequence, memory_order_acquire);
@@ -894,6 +901,19 @@ bare_channel_broadcast__get_port(bare_channel_broadcast_t *channel, int id) {
   }
 
   return port;
+}
+
+static void
+bare_channel_broadcast__on_close(bare_channel_broadcast_port_t *port) {
+  int err;
+
+  if (port->state.closing) return;
+
+  port->state.closing = true;
+
+  intrusive_list_remove(&port->channel->ports, &port->node);
+
+  free(port);
 }
 
 static js_value_t *
@@ -943,6 +963,8 @@ bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
 
   bare_channel_broadcast_port_t *port = malloc(sizeof(bare_channel_broadcast_port_t));
 
+  port->channel = channel;
+
   int id = atomic_fetch_add_explicit(&channel->next, 1, memory_order_acq_rel);
   port->id = id;
 
@@ -979,7 +1001,7 @@ bare_channel_port_broadcast_read(js_env_t *env, js_callback_info_t *info) {
   assert(err == 0);
 
   bare_channel_broadcast_port_t *port = bare_channel_broadcast__get_port(channel, id);
-  assert(port != NULL);
+  if (port == NULL) return NULL;
 
   int tail = port->tail_cursor;
 
@@ -1025,7 +1047,7 @@ bare_channel_port_broadcast_write(js_env_t *env, js_callback_info_t *info) {
   assert(err == 0);
 
   bare_channel_broadcast_port_t *port = bare_channel_broadcast__get_port(channel, id);
-  assert(port != NULL);
+  if (port == NULL) return NULL;
 
   int head = atomic_load_explicit(&channel->head_cursor, memory_order_acquire);
 
@@ -1059,6 +1081,34 @@ bare_channel_port_broadcast_write(js_env_t *env, js_callback_info_t *info) {
 }
 
 static js_value_t *
+bare_channel_port_broadcast_close(js_env_t *env, js_callback_info_t *info) {
+  int err;
+
+  size_t argc = 2;
+  js_value_t *argv[2];
+
+  err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
+  assert(err == 0);
+
+  assert(argc == 2);
+
+  bare_channel_broadcast_t *channel;
+  err = js_get_sharedarraybuffer_info(env, argv[0], (void **) &channel, NULL);
+  assert(err == 0);
+
+  int id;
+  err = js_get_value_int32(env, argv[1], &id);
+  assert(err == 0);
+
+  bare_channel_broadcast_port_t *port = bare_channel_broadcast__get_port(channel, id);
+  if (port == NULL) return NULL;
+
+  bare_channel_broadcast__on_close(port);
+
+  return NULL;
+}
+
+static js_value_t *
 bare_channel_exports(js_env_t *env, js_value_t *exports) {
   int err;
 
@@ -1088,6 +1138,7 @@ bare_channel_exports(js_env_t *env, js_value_t *exports) {
   V("broadcastPortInit", bare_channel_port_broadcast_init)
   V("broadcastPortRead", bare_channel_port_broadcast_read)
   V("broadcastPortWrite", bare_channel_port_broadcast_write)
+  V("broadcastPortClose", bare_channel_port_broadcast_close)
 #undef V
 
   return exports;

--- a/binding.c
+++ b/binding.c
@@ -1,5 +1,7 @@
 #include <assert.h>
 #include <bare.h>
+#include <intrusive.h>
+#include <intrusive/list.h>
 #include <js.h>
 #include <stdatomic.h>
 #include <stdbool.h>
@@ -7,11 +9,16 @@
 #include <string.h>
 #include <uv.h>
 
-#define BARE_CHANNEL_PORT_CAPACITY 1024
+#define BARE_CHANNEL_PORT_CAPACITY           1024
+#define BARE_CHANNEL_BROADCAST_RING_CAPACITY 8
 
 typedef struct bare_channel_s bare_channel_t;
 typedef struct bare_channel_port_s bare_channel_port_t;
 typedef struct bare_channel_message_s bare_channel_message_t;
+
+typedef struct bare_channel_broadcast_s bare_channel_broadcast_t;
+typedef struct bare_channel_broadcast_port_s bare_channel_broadcast_port_t;
+typedef struct bare_channel_broadcast_message_s bare_channel_broadcast_message_t;
 
 struct bare_channel_message_s {
   enum {
@@ -76,6 +83,35 @@ struct bare_channel_s {
   atomic_int next;
 
   bare_channel_port_t ports[2];
+};
+
+struct bare_channel_broadcast_message_s {
+  atomic_int sequence;
+
+  int writer_id;
+
+  union {
+    js_arraybuffer_backing_store_t *backing_store;
+  };
+};
+
+struct bare_channel_broadcast_port_s {
+  uint8_t id;
+
+  int tail_cursor;
+
+  intrusive_list_node_t node;
+};
+
+struct bare_channel_broadcast_s {
+  atomic_int next;
+  atomic_int head_cursor;
+
+  intrusive_list_t ports;
+
+  int buffer_mask;
+
+  bare_channel_broadcast_message_t buffer[BARE_CHANNEL_BROADCAST_RING_CAPACITY];
 };
 
 static inline bare_channel_message_t *
@@ -809,6 +845,163 @@ bare_channel_port_close(js_env_t *env, js_callback_info_t *info) {
 }
 
 static js_value_t *
+bare_channel_broadcast_init(js_env_t *env, js_callback_info_t *info) {
+  int err;
+
+  js_value_t *handle;
+
+  bare_channel_broadcast_t *channel;
+  err = js_create_sharedarraybuffer(env, sizeof(bare_channel_broadcast_t), (void **) &channel, &handle);
+  assert(err == 0);
+
+  atomic_init(&channel->next, 0);
+  atomic_init(&channel->head_cursor, 0);
+
+  intrusive_list_init(&channel->ports);
+
+  for (size_t i = 0; i < BARE_CHANNEL_BROADCAST_RING_CAPACITY; i++) {
+    bare_channel_broadcast_message_t *message = &channel->buffer[i];
+
+    message->writer_id = -1;
+
+    atomic_init(&message->sequence, i);
+  }
+
+  channel->buffer_mask = BARE_CHANNEL_BROADCAST_RING_CAPACITY - 1;
+
+  return handle;
+}
+
+static js_value_t *
+bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
+  int err;
+
+  size_t argc = 1;
+  js_value_t *argv[1];
+
+  err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
+  assert(err == 0);
+
+  assert(argc == 1);
+
+  bare_channel_broadcast_t *channel;
+  err = js_get_sharedarraybuffer_info(env, argv[0], (void **) &channel, NULL);
+  assert(err == 0);
+
+  js_value_t *handle;
+
+  bare_channel_broadcast_port_t *port;
+  err = js_create_arraybuffer(env, sizeof(bare_channel_broadcast_port_t), (void **) &port, &handle);
+  assert(err == 0);
+
+  int id = atomic_fetch_add_explicit(&channel->next, 1, memory_order_acq_rel);
+  port->id = id;
+
+  port->tail_cursor = 0;
+
+  int tail = port->tail_cursor;
+
+  intrusive_list_append(&channel->ports, &port->node);
+
+  return handle;
+}
+
+static js_value_t *
+bare_channel_port_broadcast_read(js_env_t *env, js_callback_info_t *info) {
+  int err;
+
+  size_t argc = 2;
+  js_value_t *argv[2];
+
+  err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
+  assert(err == 0);
+
+  assert(argc == 2);
+
+  bare_channel_broadcast_port_t *port;
+  err = js_get_arraybuffer_info(env, argv[0], (void **) &port, NULL);
+  assert(err == 0);
+
+  bare_channel_broadcast_t *channel;
+  err = js_get_sharedarraybuffer_info(env, argv[1], (void **) &channel, NULL);
+  assert(err == 0);
+
+  int tail = port->tail_cursor;
+
+  bare_channel_broadcast_message_t *message = &channel->buffer[tail & channel->buffer_mask];
+
+  int sequence = atomic_load_explicit(&message->sequence, memory_order_relaxed);
+
+  int dif = sequence - (tail + 1);
+
+  js_value_t *result;
+
+  if (dif == 0) {
+    port->tail_cursor++;
+
+    err = js_create_arraybuffer_with_backing_store(env, message->backing_store, NULL, NULL, &result);
+    assert(err == 0);
+
+    err = js_release_arraybuffer_backing_store(env, message->backing_store);
+    assert(err == 0);
+  } else {
+    err = js_get_null(env, &result);
+    assert(err == 0);
+  }
+
+  return result;
+}
+
+static js_value_t *
+bare_channel_port_broadcast_write(js_env_t *env, js_callback_info_t *info) {
+  int err;
+
+  size_t argc = 3;
+  js_value_t *argv[3];
+
+  err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
+  assert(err == 0);
+
+  assert(argc == 3);
+
+  bare_channel_broadcast_port_t *port;
+  err = js_get_arraybuffer_info(env, argv[0], (void **) &port, NULL);
+  assert(err == 0);
+
+  bare_channel_broadcast_t *channel;
+  err = js_get_sharedarraybuffer_info(env, argv[1], (void **) &channel, NULL);
+  assert(err == 0);
+
+  int head = atomic_load_explicit(&channel->head_cursor, memory_order_acquire);
+
+  bare_channel_broadcast_message_t *message = &channel->buffer[head & channel->buffer_mask];
+
+  int sequence = atomic_load_explicit(&message->sequence, memory_order_acquire);
+
+  int dif = sequence - head;
+
+  if (dif == 0) {
+    err = js_get_arraybuffer_backing_store(env, argv[2], &message->backing_store);
+    assert(err == 0);
+
+    err = js_detach_arraybuffer(env, argv[2]);
+    assert(err == 0);
+
+    atomic_store_explicit(&channel->head_cursor, head + 1, memory_order_release);
+    atomic_store_explicit(&message->sequence, sequence + 1, memory_order_release);
+  } else {
+    atomic_store_explicit(&channel->head_cursor, head, memory_order_release);
+    atomic_store_explicit(&message->sequence, sequence, memory_order_release);
+  }
+
+  js_value_t *result;
+  err = js_get_boolean(env, dif == 0, &result);
+  assert(err == 0);
+
+  return result;
+}
+
+static js_value_t *
 bare_channel_exports(js_env_t *env, js_value_t *exports) {
   int err;
 
@@ -832,6 +1025,12 @@ bare_channel_exports(js_env_t *env, js_value_t *exports) {
   V("portRef", bare_channel_port_ref)
   V("portUnref", bare_channel_port_unref)
   V("portClose", bare_channel_port_close)
+
+  V("channelBroadcastInit", bare_channel_broadcast_init)
+
+  V("broadcastPortInit", bare_channel_port_broadcast_init)
+  V("broadcastPortRead", bare_channel_port_broadcast_read)
+  V("broadcastPortWrite", bare_channel_port_broadcast_write)
 #undef V
 
   return exports;

--- a/binding.c
+++ b/binding.c
@@ -92,7 +92,7 @@ struct bare_channel_broadcast_message_s {
   int writer_id;
 
   union {
-    js_arraybuffer_backing_store_t *backing_store;
+    js_value_t *sharedarraybuffer;
   };
 };
 
@@ -944,8 +944,8 @@ bare_channel_port_broadcast__after_read(js_env_t *env, bare_channel_broadcast_t 
 
     message->writer_id = -1;
 
-    err = js_release_arraybuffer_backing_store(env, message->backing_store);
-    assert(err == 0);
+    // err = js_release_arraybuffer_backing_store(env, message->backing_store);
+    // assert(err == 0);
 
     atomic_store_explicit(&message->sequence, sequence + channel->buffer_mask, memory_order_release);
   }
@@ -1238,8 +1238,7 @@ bare_channel_port_broadcast_read(js_env_t *env, js_callback_info_t *info) {
   js_value_t *result;
 
   if (message) {
-    js_value_t *sharedarraybuffer;
-    err = js_create_sharedarraybuffer_with_backing_store(env, message->backing_store, (void **) &result, NULL, &sharedarraybuffer);
+    err = js_get_sharedarraybuffer_info(env, message->sharedarraybuffer, (void **) &result, NULL);
     assert(err == 0);
 
     bare_channel_port_broadcast__after_read(env, channel);
@@ -1280,11 +1279,7 @@ bare_channel_port_broadcast_write(js_env_t *env, js_callback_info_t *info) {
   if (dif == 0) {
     message->writer_id = port->id;
 
-    js_value_t *sharedarraybuffer;
-    err = js_create_sharedarraybuffer(env, sizeof(js_value_t *), (void **) &argv[1], &sharedarraybuffer);
-    assert(err == 0);
-
-    err = js_get_sharedarraybuffer_backing_store(env, sharedarraybuffer, &message->backing_store);
+    err = js_create_sharedarraybuffer(env, sizeof(js_value_t *), (void **) &argv[1], &message->sharedarraybuffer);
     assert(err == 0);
 
     atomic_store_explicit(&channel->head_cursor, head + 1, memory_order_release);

--- a/binding.c
+++ b/binding.c
@@ -106,7 +106,7 @@ struct bare_channel_broadcast_port_s {
   intrusive_list_node_t node;
 
   struct {
-    bool closing;
+    atomic_bool closing;
     uint8_t closing_count;
   } state;
 
@@ -908,9 +908,8 @@ bare_channel_port_broadcast__after_read(js_env_t *env, bare_channel_broadcast_t 
   intrusive_list_for_each(next, &channel->ports) {
     bare_channel_broadcast_port_t *port = intrusive_entry(next, bare_channel_broadcast_port_t, node);
 
-    if (port->state.closing) {
-      continue;
-    }
+    bool closing = atomic_load_explicit(&port->state.closing, memory_order_relaxed);
+    if (closing) continue;
 
     if (port->tail_cursor < min_port_tail) {
       min_port_tail = port->tail_cursor;
@@ -1184,7 +1183,7 @@ bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
 
   uv_mutex_unlock(&channel->lock);
 
-  port->state.closing = false;
+  atomic_init(&port->state.closing, false);
   port->state.closing_count = 0;
 
   port->env = env;
@@ -1303,9 +1302,12 @@ bare_channel_port_broadcast_write(js_env_t *env, js_callback_info_t *info) {
 
 static inline void
 bare_channel_port_broadcast__close(bare_channel_broadcast_port_t *port) {
-  if (port->state.closing) return;
+  if (atomic_load_explicit(&port->state.closing, memory_order_relaxed)) {
+    return;
+  }
 
-  port->state.closing = true;
+  atomic_store_explicit(&port->state.closing, true, memory_order_seq_cst);
+
   port->state.closing_count = 2;
 
   bare_channel_port_broadcast__after_read(port->env, port->channel);

--- a/binding.c
+++ b/binding.c
@@ -889,7 +889,7 @@ bare_channel_broadcast__recycle_queue(js_env_t *env, bare_channel_broadcast_t *c
   int curr_tail = atomic_load_explicit(&channel->tail_cursor, memory_order_acquire);
 
   if (min_tail > curr_tail) {
-    for (int i = channel->tail_cursor; i < min_tail; i++) {
+    for (int i = curr_tail; i < min_tail; i++) {
       bare_channel_broadcast_message_t *message = &channel->buffer[i & channel->buffer_mask];
 
       int sequence = atomic_load_explicit(&message->sequence, memory_order_acquire);

--- a/binding.c
+++ b/binding.c
@@ -105,10 +105,9 @@ struct bare_channel_broadcast_port_s {
 
   intrusive_list_node_t node;
 
-  struct {
-    bool closing;
-    bool exiting;
-  } state;
+  bool closing;
+
+  js_deferred_teardown_t *teardown;
 };
 
 struct bare_channel_broadcast_s {
@@ -909,13 +908,25 @@ static void
 bare_channel_broadcast__on_close(bare_channel_broadcast_port_t *port) {
   int err;
 
-  if (port->state.closing) return;
+  port->closing = true;
 
-  port->state.closing = true;
+  js_deferred_teardown_t *teardown = port->teardown;
 
   intrusive_list_remove(&port->channel->ports, &port->node);
 
   free(port);
+
+  err = js_finish_deferred_teardown_callback(teardown);
+  assert(err == 0);
+}
+
+static void
+bare_channel_broadcast__on_teardown(js_deferred_teardown_t *handle, void *data) {
+  bare_channel_broadcast_port_t *port = data;
+
+  if (port->closing) return;
+
+  bare_channel_broadcast__on_close(port);
 }
 
 static js_value_t *
@@ -974,6 +985,11 @@ bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
   port->tail_cursor = initial_tail;
 
   intrusive_list_append(&channel->ports, &port->node);
+
+  port->closing = false;
+
+  err = js_add_deferred_teardown_callback(env, bare_channel_broadcast__on_teardown, (void *) port, &port->teardown);
+  assert(err == 0);
 
   js_value_t *result;
   err = js_create_int32(env, id, &result);
@@ -1107,9 +1123,10 @@ bare_channel_port_broadcast_close(js_env_t *env, js_callback_info_t *info) {
   assert(err == 0);
 
   bare_channel_broadcast_port_t *port = bare_channel_broadcast__get_port(channel, id);
-  if (port == NULL) return NULL;
 
-  bare_channel_broadcast__on_close(port);
+  if (port != NULL) {
+    bare_channel_broadcast__on_close(port);
+  }
 
   return NULL;
 }

--- a/binding.c
+++ b/binding.c
@@ -3,6 +3,7 @@
 #include <intrusive.h>
 #include <intrusive/list.h>
 #include <js.h>
+#include <limits.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -106,10 +107,11 @@ struct bare_channel_broadcast_port_s {
 struct bare_channel_broadcast_s {
   atomic_int next;
   atomic_int head_cursor;
-
-  intrusive_list_t ports;
+  atomic_int tail_cursor;
 
   int buffer_mask;
+
+  intrusive_list_t ports;
 
   bare_channel_broadcast_message_t buffer[BARE_CHANNEL_BROADCAST_RING_CAPACITY];
 };
@@ -844,6 +846,56 @@ bare_channel_port_close(js_env_t *env, js_callback_info_t *info) {
   return NULL;
 }
 
+static void
+bare_channel_broadcast__recycle_queue(js_env_t *env, bare_channel_broadcast_t *channel) {
+  int err;
+
+  int min_tail = INT_MAX;
+
+  intrusive_list_for_each(next, &channel->ports) {
+    bare_channel_broadcast_port_t *port = intrusive_entry(next, bare_channel_broadcast_port_t, node);
+
+    if (port->tail_cursor < min_tail) {
+      min_tail = port->tail_cursor;
+    }
+  }
+
+  int curr_tail = atomic_load_explicit(&channel->tail_cursor, memory_order_acquire);
+
+  if (min_tail > curr_tail) {
+    for (int i = channel->tail_cursor; i <= min_tail; i++) {
+      bare_channel_broadcast_message_t *message = &channel->buffer[i & channel->buffer_mask];
+
+      int sequence = atomic_load_explicit(&message->sequence, memory_order_acquire);
+
+      err = js_release_arraybuffer_backing_store(env, message->backing_store);
+      assert(err == 0);
+
+      atomic_store_explicit(&message->sequence, sequence + channel->buffer_mask, memory_order_release);
+    }
+
+    atomic_store_explicit(&channel->tail_cursor, min_tail, memory_order_release);
+  } else {
+    atomic_store_explicit(&channel->tail_cursor, curr_tail, memory_order_release);
+  }
+}
+
+static bare_channel_broadcast_port_t *
+bare_channel_broadcast__get_port(bare_channel_broadcast_t *channel, int id) {
+  bare_channel_broadcast_port_t *port = NULL;
+
+  intrusive_list_for_each(next, &channel->ports) {
+    bare_channel_broadcast_port_t *entry = intrusive_entry(next, bare_channel_broadcast_port_t, node);
+
+    if (entry->id == id) {
+      port = entry;
+      break;
+    }
+  }
+
+  return port;
+}
+
 static js_value_t *
 bare_channel_broadcast_init(js_env_t *env, js_callback_info_t *info) {
   int err;
@@ -856,6 +908,7 @@ bare_channel_broadcast_init(js_env_t *env, js_callback_info_t *info) {
 
   atomic_init(&channel->next, 0);
   atomic_init(&channel->head_cursor, 0);
+  atomic_init(&channel->tail_cursor, 0);
 
   intrusive_list_init(&channel->ports);
 
@@ -888,22 +941,21 @@ bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
   err = js_get_sharedarraybuffer_info(env, argv[0], (void **) &channel, NULL);
   assert(err == 0);
 
-  js_value_t *handle;
-
-  bare_channel_broadcast_port_t *port;
-  err = js_create_arraybuffer(env, sizeof(bare_channel_broadcast_port_t), (void **) &port, &handle);
-  assert(err == 0);
+  bare_channel_broadcast_port_t *port = malloc(sizeof(bare_channel_broadcast_port_t));
 
   int id = atomic_fetch_add_explicit(&channel->next, 1, memory_order_acq_rel);
   port->id = id;
 
-  port->tail_cursor = 0;
-
-  int tail = port->tail_cursor;
+  int initial_tail = atomic_load_explicit(&channel->tail_cursor, memory_order_relaxed);
+  port->tail_cursor = initial_tail;
 
   intrusive_list_append(&channel->ports, &port->node);
 
-  return handle;
+  js_value_t *result;
+  err = js_create_int32(env, id, &result);
+  assert(err == 0);
+
+  return result;
 }
 
 static js_value_t *
@@ -918,13 +970,16 @@ bare_channel_port_broadcast_read(js_env_t *env, js_callback_info_t *info) {
 
   assert(argc == 2);
 
-  bare_channel_broadcast_port_t *port;
-  err = js_get_arraybuffer_info(env, argv[0], (void **) &port, NULL);
+  bare_channel_broadcast_t *channel;
+  err = js_get_sharedarraybuffer_info(env, argv[0], (void **) &channel, NULL);
   assert(err == 0);
 
-  bare_channel_broadcast_t *channel;
-  err = js_get_sharedarraybuffer_info(env, argv[1], (void **) &channel, NULL);
+  int id;
+  err = js_get_value_int32(env, argv[1], &id);
   assert(err == 0);
+
+  bare_channel_broadcast_port_t *port = bare_channel_broadcast__get_port(channel, id);
+  assert(port != NULL);
 
   int tail = port->tail_cursor;
 
@@ -940,9 +995,6 @@ bare_channel_port_broadcast_read(js_env_t *env, js_callback_info_t *info) {
     port->tail_cursor++;
 
     err = js_create_arraybuffer_with_backing_store(env, message->backing_store, NULL, NULL, &result);
-    assert(err == 0);
-
-    err = js_release_arraybuffer_backing_store(env, message->backing_store);
     assert(err == 0);
   } else {
     err = js_get_null(env, &result);
@@ -964,13 +1016,16 @@ bare_channel_port_broadcast_write(js_env_t *env, js_callback_info_t *info) {
 
   assert(argc == 3);
 
-  bare_channel_broadcast_port_t *port;
-  err = js_get_arraybuffer_info(env, argv[0], (void **) &port, NULL);
+  bare_channel_broadcast_t *channel;
+  err = js_get_sharedarraybuffer_info(env, argv[0], (void **) &channel, NULL);
   assert(err == 0);
 
-  bare_channel_broadcast_t *channel;
-  err = js_get_sharedarraybuffer_info(env, argv[1], (void **) &channel, NULL);
+  int id;
+  err = js_get_value_int32(env, argv[1], &id);
   assert(err == 0);
+
+  bare_channel_broadcast_port_t *port = bare_channel_broadcast__get_port(channel, id);
+  assert(port != NULL);
 
   int head = atomic_load_explicit(&channel->head_cursor, memory_order_acquire);
 
@@ -992,6 +1047,8 @@ bare_channel_port_broadcast_write(js_env_t *env, js_callback_info_t *info) {
   } else {
     atomic_store_explicit(&channel->head_cursor, head, memory_order_release);
     atomic_store_explicit(&message->sequence, sequence, memory_order_release);
+
+    if (dif < 0) bare_channel_broadcast__recycle_queue(env, channel);
   }
 
   js_value_t *result;

--- a/binding.c
+++ b/binding.c
@@ -105,7 +105,21 @@ struct bare_channel_broadcast_port_s {
 
   intrusive_list_node_t node;
 
-  bool closing;
+  struct {
+    bool closing;
+    uint8_t closing_count;
+  } state;
+
+  struct {
+    uv_async_t drain;
+    uv_async_t flush;
+  } signals;
+
+  js_env_t *env;
+  js_ref_t *ctx;
+  js_ref_t *on_drain;
+  js_ref_t *on_flush;
+  js_ref_t *on_close;
 
   js_deferred_teardown_t *teardown;
 };
@@ -871,6 +885,171 @@ bare_channel_broadcast__on_teardown(js_deferred_teardown_t *handle, void *data) 
 }
 
 static void
+bare_channel_port_broadcast__on_close(uv_handle_t *handle) {
+  int err;
+
+  bare_channel_broadcast_port_t *port = handle->data;
+
+  if (--port->state.closing_count != 0) return;
+
+  js_deferred_teardown_t *teardown = port->teardown;
+
+  js_env_t *env = port->env;
+
+  js_handle_scope_t *scope;
+  err = js_open_handle_scope(env, &scope);
+  assert(err == 0);
+
+  js_value_t *ctx;
+  err = js_get_reference_value(env, port->ctx, &ctx);
+  assert(err == 0);
+
+  js_value_t *on_destroy;
+  err = js_get_reference_value(env, port->on_close, &on_destroy);
+  assert(err == 0);
+
+  err = js_delete_reference(env, port->on_drain);
+  assert(err == 0);
+
+  err = js_delete_reference(env, port->on_flush);
+  assert(err == 0);
+
+  err = js_delete_reference(env, port->on_close);
+  assert(err == 0);
+
+  err = js_delete_reference(env, port->ctx);
+  assert(err == 0);
+
+  uv_mutex_lock(&port->channel->lock);
+
+  intrusive_list_remove(&port->channel->ports, &port->node);
+
+  uv_mutex_unlock(&port->channel->lock);
+
+  js_call_function(env, ctx, on_destroy, 0, NULL, NULL);
+
+  err = js_close_handle_scope(env, scope);
+  assert(err == 0);
+
+  err = js_finish_deferred_teardown_callback(teardown);
+  assert(err == 0);
+}
+
+static inline void
+bare_channel_port_broadcast__close(bare_channel_broadcast_port_t *port) {
+  if (port->state.closing) return;
+
+  port->state.closing = true;
+  port->state.closing_count = 2;
+
+  uv_close((uv_handle_t *) &port->signals.drain, bare_channel_port_broadcast__on_close);
+  uv_close((uv_handle_t *) &port->signals.flush, bare_channel_port_broadcast__on_close);
+}
+
+static void
+bare_channel_port_broadcast__on_teardown(js_deferred_teardown_t *handle, void *data) {
+  bare_channel_broadcast_port_t *port = data;
+
+  bare_channel_port_broadcast__close(port);
+}
+
+static void
+bare_channel_port_broadcast__on_drain(uv_async_t *handle) {
+  int err;
+
+  bare_channel_broadcast_port_t *port = handle->data;
+
+  if (port->state.closing) return;
+
+  js_env_t *env = port->env;
+
+  js_handle_scope_t *scope;
+  err = js_open_handle_scope(env, &scope);
+  assert(err == 0);
+
+  js_value_t *ctx;
+  err = js_get_reference_value(env, port->ctx, &ctx);
+  assert(err == 0);
+
+  js_value_t *on_drain;
+  err = js_get_reference_value(env, port->on_drain, &on_drain);
+  assert(err == 0);
+
+  js_call_function(env, ctx, on_drain, 0, NULL, NULL);
+
+  err = js_close_handle_scope(env, scope);
+  assert(err == 0);
+}
+
+static void
+bare_channel_port_broadcast__on_flush(uv_async_t *handle) {
+  int err;
+
+  bare_channel_broadcast_port_t *port = handle->data;
+
+  if (port->state.closing) return;
+
+  js_env_t *env = port->env;
+
+  js_handle_scope_t *scope;
+  err = js_open_handle_scope(env, &scope);
+  assert(err == 0);
+
+  js_value_t *ctx;
+  err = js_get_reference_value(env, port->ctx, &ctx);
+  assert(err == 0);
+
+  js_value_t *on_flush;
+  err = js_get_reference_value(env, port->on_flush, &on_flush);
+  assert(err == 0);
+
+  js_call_function(env, ctx, on_flush, 0, NULL, NULL);
+
+  err = js_close_handle_scope(env, scope);
+  assert(err == 0);
+}
+
+static void
+bare_channel_port_broadcast__on_read(bare_channel_broadcast_port_t *reader) {
+  int err;
+
+  uv_mutex_lock(&reader->channel->lock);
+
+  intrusive_list_for_each(next, &reader->channel->ports) {
+    bare_channel_broadcast_port_t *port = intrusive_entry(next, bare_channel_broadcast_port_t, node);
+
+    if (port->state.closing || port->id == reader->id) {
+      continue;
+    }
+
+    err = uv_async_send(&port->signals.drain);
+    assert(err == 0);
+  }
+
+  uv_mutex_unlock(&reader->channel->lock);
+}
+
+static void
+bare_channel_port_broadcast__on_write(bare_channel_broadcast_port_t *writer) {
+  int err;
+
+  uv_mutex_lock(&writer->channel->lock);
+
+  intrusive_list_for_each(next, &writer->channel->ports) {
+    bare_channel_broadcast_port_t *port = intrusive_entry(next, bare_channel_broadcast_port_t, node);
+
+    if (port->state.closing || port->id == writer->id) {
+      continue;
+    }
+
+    err = uv_async_send(&port->signals.flush);
+    assert(err == 0);
+  }
+
+  uv_mutex_unlock(&writer->channel->lock);
+}
+
+static bool
 bare_channel_broadcast__recycle_queue(js_env_t *env, bare_channel_broadcast_t *channel) {
   int err;
 
@@ -885,6 +1064,8 @@ bare_channel_broadcast__recycle_queue(js_env_t *env, bare_channel_broadcast_t *c
       min_tail = port->tail_cursor;
     }
   }
+
+  uv_mutex_unlock(&channel->lock);
 
   int curr_tail = atomic_load_explicit(&channel->tail_cursor, memory_order_acquire);
 
@@ -907,34 +1088,7 @@ bare_channel_broadcast__recycle_queue(js_env_t *env, bare_channel_broadcast_t *c
     atomic_store_explicit(&channel->tail_cursor, curr_tail, memory_order_release);
   }
 
-  uv_mutex_unlock(&channel->lock);
-}
-
-static void
-bare_channel_port_broadcast__on_close(bare_channel_broadcast_port_t *port) {
-  int err;
-
-  port->closing = true;
-
-  js_deferred_teardown_t *teardown = port->teardown;
-
-  uv_mutex_lock(&port->channel->lock);
-
-  intrusive_list_remove(&port->channel->ports, &port->node);
-
-  uv_mutex_unlock(&port->channel->lock);
-
-  err = js_finish_deferred_teardown_callback(teardown);
-  assert(err == 0);
-}
-
-static void
-bare_channel_port_broadcast__on_teardown(js_deferred_teardown_t *handle, void *data) {
-  bare_channel_broadcast_port_t *port = data;
-
-  if (port->closing) return;
-
-  bare_channel_port_broadcast__on_close(port);
+  return min_tail > curr_tail;
 }
 
 static js_value_t *
@@ -976,13 +1130,13 @@ static js_value_t *
 bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
   int err;
 
-  size_t argc = 1;
-  js_value_t *argv[1];
+  size_t argc = 5;
+  js_value_t *argv[5];
 
   err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
   assert(err == 0);
 
-  assert(argc == 1);
+  assert(argc == 5);
 
   bare_channel_broadcast_t *channel;
   err = js_get_sharedarraybuffer_info(env, argv[0], (void **) &channel, NULL);
@@ -994,7 +1148,25 @@ bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
   err = js_create_arraybuffer(env, sizeof(bare_channel_broadcast_port_t), (void **) &port, &handle);
   assert(err == 0);
 
+  uv_loop_t *loop;
+  err = js_get_env_loop(env, &loop);
+  assert(err == 0);
+
   port->channel = channel;
+
+  port->env = env;
+
+  err = js_create_reference(env, argv[1], 1, &port->ctx);
+  assert(err == 0);
+
+  err = js_create_reference(env, argv[2], 1, &port->on_drain);
+  assert(err == 0);
+
+  err = js_create_reference(env, argv[3], 1, &port->on_flush);
+  assert(err == 0);
+
+  err = js_create_reference(env, argv[4], 1, &port->on_close);
+  assert(err == 0);
 
   uv_mutex_lock(&channel->lock);
 
@@ -1008,12 +1180,61 @@ bare_channel_port_broadcast_init(js_env_t *env, js_callback_info_t *info) {
 
   uv_mutex_unlock(&channel->lock);
 
-  port->closing = false;
+  port->state.closing = false;
+  port->state.closing_count = 0;
 
   err = js_add_deferred_teardown_callback(env, bare_channel_port_broadcast__on_teardown, (void *) port, &port->teardown);
   assert(err == 0);
 
+#define V(signal) \
+  err = uv_async_init(loop, &port->signals.signal, bare_channel_port_broadcast__on_##signal); \
+  assert(err == 0); \
+  port->signals.signal.data = (void *) port;
+  V(drain)
+  V(flush)
+#undef V
+
+  err = uv_async_send(&port->signals.flush);
+  assert(err == 0);
+
   return handle;
+}
+
+static js_value_t *
+bare_channel_port_broadcast__read(js_env_t *env, bare_channel_broadcast_port_t *port) {
+  int err;
+
+  bare_channel_broadcast_t *channel = port->channel;
+
+  int tail = port->tail_cursor;
+
+  bare_channel_broadcast_message_t *message = &channel->buffer[tail & channel->buffer_mask];
+
+  int sequence = atomic_load_explicit(&message->sequence, memory_order_relaxed);
+
+  int dif = sequence - (tail + 1);
+
+  if (dif == 0 && message->writer_id == port->id) {
+    port->tail_cursor++;
+
+    return bare_channel_port_broadcast__read(env, port);
+  }
+
+  js_value_t *result;
+
+  if (dif == 0) {
+    port->tail_cursor++;
+
+    err = js_create_arraybuffer_with_backing_store(env, message->backing_store, NULL, NULL, &result);
+    assert(err == 0);
+
+    bare_channel_port_broadcast__on_read(port);
+  } else {
+    err = js_get_null(env, &result);
+    assert(err == 0);
+  }
+
+  return result;
 }
 
 static js_value_t *
@@ -1032,31 +1253,42 @@ bare_channel_port_broadcast_read(js_env_t *env, js_callback_info_t *info) {
   err = js_get_arraybuffer_info(env, argv[0], (void **) &port, NULL);
   assert(err == 0);
 
+  return bare_channel_port_broadcast__read(env, port);
+}
+
+static int
+bare_channel_port_broadcast__write(js_env_t *env, bare_channel_broadcast_port_t *port, js_value_t *payload) {
+  int err;
+
   bare_channel_broadcast_t *channel = port->channel;
 
-  int tail = port->tail_cursor;
+  int head = atomic_load_explicit(&channel->head_cursor, memory_order_acquire);
 
-  bare_channel_broadcast_message_t *message = &channel->buffer[tail & channel->buffer_mask];
+  bare_channel_broadcast_message_t *message = &channel->buffer[head & channel->buffer_mask];
 
-  int sequence = atomic_load_explicit(&message->sequence, memory_order_relaxed);
+  int sequence = atomic_load_explicit(&message->sequence, memory_order_acquire);
 
-  int dif = sequence - (tail + 1);
+  int dif = sequence - head;
 
   if (dif == 0) {
-    port->tail_cursor++;
-  }
-
-  js_value_t *result;
-
-  if (dif == 0 && message->writer_id != port->id) {
-    err = js_create_arraybuffer_with_backing_store(env, message->backing_store, NULL, NULL, &result);
+    err = js_get_arraybuffer_backing_store(env, payload, &message->backing_store);
     assert(err == 0);
+
+    err = js_detach_arraybuffer(env, payload);
+    assert(err == 0);
+
+    message->writer_id = port->id;
+
+    atomic_store_explicit(&channel->head_cursor, head + 1, memory_order_release);
+    atomic_store_explicit(&message->sequence, sequence + 1, memory_order_release);
+
+    bare_channel_port_broadcast__on_write(port);
   } else {
-    err = js_get_null(env, &result);
-    assert(err == 0);
+    atomic_store_explicit(&channel->head_cursor, head, memory_order_release);
+    atomic_store_explicit(&message->sequence, sequence, memory_order_release);
   }
 
-  return result;
+  return dif;
 }
 
 static js_value_t *
@@ -1075,32 +1307,12 @@ bare_channel_port_broadcast_write(js_env_t *env, js_callback_info_t *info) {
   err = js_get_arraybuffer_info(env, argv[0], (void **) &port, NULL);
   assert(err == 0);
 
-  bare_channel_broadcast_t *channel = port->channel;
+  int dif = bare_channel_port_broadcast__write(env, port, argv[1]);
 
-  int head = atomic_load_explicit(&channel->head_cursor, memory_order_acquire);
-
-  bare_channel_broadcast_message_t *message = &channel->buffer[head & channel->buffer_mask];
-
-  int sequence = atomic_load_explicit(&message->sequence, memory_order_acquire);
-
-  int dif = sequence - head;
-
-  if (dif == 0) {
-    err = js_get_arraybuffer_backing_store(env, argv[1], &message->backing_store);
-    assert(err == 0);
-
-    err = js_detach_arraybuffer(env, argv[1]);
-    assert(err == 0);
-
-    message->writer_id = port->id;
-
-    atomic_store_explicit(&channel->head_cursor, head + 1, memory_order_release);
-    atomic_store_explicit(&message->sequence, sequence + 1, memory_order_release);
-  } else {
-    atomic_store_explicit(&channel->head_cursor, head, memory_order_release);
-    atomic_store_explicit(&message->sequence, sequence, memory_order_release);
-
-    if (dif < 0) bare_channel_broadcast__recycle_queue(env, channel);
+  if (dif < 0) {
+    if (bare_channel_broadcast__recycle_queue(env, port->channel)) {
+      dif = bare_channel_port_broadcast__write(env, port, argv[1]);
+    }
   }
 
   js_value_t *result;
@@ -1126,7 +1338,7 @@ bare_channel_port_broadcast_close(js_env_t *env, js_callback_info_t *info) {
   err = js_get_arraybuffer_info(env, argv[0], (void **) &port, NULL);
   assert(err == 0);
 
-  bare_channel_port_broadcast__on_close(port);
+  bare_channel_port_broadcast__close(port);
 
   return NULL;
 }

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 const EventEmitter = require('bare-events')
 const { Readable, Writable, Duplex } = require('bare-stream')
-const structuredClone = require('bare-structured-clone')
 const binding = require('./binding')
 const Queue = require('./lib/queue')
+const { encode, decode } = require('./lib/encode-decode')
 
 const ENDED = 0x1
 const REMOTE_ENDED = 0x2
@@ -319,30 +319,4 @@ class PortDuplexStream extends Duplex {
 
     cb(err)
   }
-}
-
-function encode(channel, value, opts) {
-  const serialized = structuredClone.serializeWithTransfer(value, opts.transfer, channel.interfaces)
-
-  const state = { start: 0, end: 0, buffer: null }
-
-  structuredClone.preencode(state, serialized)
-
-  const data = new ArrayBuffer(state.end)
-
-  state.buffer = Buffer.from(data)
-
-  structuredClone.encode(state, serialized)
-
-  return data
-}
-
-function decode(channel, data) {
-  const state = {
-    start: 0,
-    end: data.byteLength,
-    buffer: Buffer.from(data)
-  }
-
-  return structuredClone.deserializeWithTransfer(structuredClone.decode(state), channel.interfaces)
 }

--- a/lib/broadcast-channel.js
+++ b/lib/broadcast-channel.js
@@ -27,7 +27,7 @@ class BroadcastPort {
     this._drain = null
     this._flush = null
 
-    this._handle = binding.broadcastPortInit(channel.handle)
+    this._id = binding.broadcastPortInit(this._channel.handle)
   }
 
   async read() {
@@ -45,7 +45,7 @@ class BroadcastPort {
       await new Promise((resolve) => setTimeout(resolve))
 
       while (this._queue.length < this._queue.capacity) {
-        const data = binding.broadcastPortRead(this._handle, this._channel.handle)
+        const data = binding.broadcastPortRead(this._channel.handle, this._id)
 
         if (data === null) break
 
@@ -64,7 +64,7 @@ class BroadcastPort {
     const data = encode(this._channel, value, opts)
 
     while (true) {
-      const flushed = binding.broadcastPortWrite(this._handle, this._channel.handle, data)
+      const flushed = binding.broadcastPortWrite(this._channel.handle, this._id, data)
 
       if (flushed) {
         this._ondrain()

--- a/lib/broadcast-channel.js
+++ b/lib/broadcast-channel.js
@@ -20,14 +20,19 @@ module.exports = class BroadcastChannel {
 }
 
 class BroadcastPort {
+  static _ports = new Set()
+
   constructor(channel) {
     this._channel = channel
     this._queue = new Queue()
 
     this._drain = null
     this._flush = null
+    this._close = null
 
     this._id = binding.broadcastPortInit(this._channel.handle)
+
+    BroadcastPort._ports.add(this)
   }
 
   async read() {
@@ -76,6 +81,20 @@ class BroadcastPort {
     }
   }
 
+  async close() {
+    while (this._drain !== null) await this._drain.promise
+
+    if (this._close !== null) return this._close.promise
+
+    this._close = Promise.withResolvers()
+
+    binding.broadcastPortClose(this._channel.handle, this._id)
+
+    BroadcastPort._ports.delete(this)
+
+    this._close.resolve()
+  }
+
   _ondrain() {
     if (this._drain === null) return
 
@@ -92,3 +111,9 @@ class BroadcastPort {
     flushing.resolve()
   }
 }
+
+Bare.on('exit', () => {
+  for (const port of BroadcastPort._ports) {
+    port.close()
+  }
+})

--- a/lib/broadcast-channel.js
+++ b/lib/broadcast-channel.js
@@ -1,0 +1,41 @@
+const binding = require('../binding')
+const { encode, decode } = require('./encode-decode')
+
+module.exports = class BroadcastChannel {
+  constructor(opts = {}) {
+    const { handle = binding.channelBroadcastInit(), interfaces = [] } = opts
+
+    this.handle = handle
+    this.interfaces = interfaces
+  }
+
+  connect() {
+    return new BroadcastPort(this)
+  }
+
+  static from(handle, opts = {}) {
+    return new BroadcastChannel({ ...opts, handle })
+  }
+}
+
+class BroadcastPort {
+  constructor(channel) {
+    this._channel = channel
+
+    this._handle = binding.broadcastPortInit(channel.handle)
+  }
+
+  read() {
+    const data = binding.broadcastPortRead(this._handle, this._channel.handle)
+
+    if (data == null) return null
+
+    return decode(this._channel, data)
+  }
+
+  write(value, opts = {}) {
+    const data = encode(this._channel, value, opts)
+
+    return binding.broadcastPortWrite(this._handle, this._channel.handle, data)
+  }
+}

--- a/lib/broadcast-channel.js
+++ b/lib/broadcast-channel.js
@@ -24,6 +24,7 @@ class BroadcastPort {
     this._channel = channel
     this._queue = new Queue()
 
+    this._drain = null
     this._flush = null
 
     this._handle = binding.broadcastPortInit(channel.handle)
@@ -41,6 +42,8 @@ class BroadcastPort {
         return this._queue.shift()
       }
 
+      await new Promise((resolve) => setTimeout(resolve))
+
       while (this._queue.length < this._queue.capacity) {
         const data = binding.broadcastPortRead(this._handle, this._channel.handle)
 
@@ -48,15 +51,37 @@ class BroadcastPort {
 
         this._queue.push(decode(this._channel, data))
       }
+    }
+  }
+
+  async write(value, opts = {}) {
+    if (value === null) return false
+
+    while (this._drain !== null) await this._drain.promise
+
+    this._drain = Promise.withResolvers()
+
+    const data = encode(this._channel, value, opts)
+
+    while (true) {
+      const flushed = binding.broadcastPortWrite(this._handle, this._channel.handle, data)
+
+      if (flushed) {
+        this._ondrain()
+
+        return true
+      }
 
       await new Promise((resolve) => setTimeout(resolve))
     }
   }
 
-  write(value, opts = {}) {
-    const data = encode(this._channel, value, opts)
+  _ondrain() {
+    if (this._drain === null) return
 
-    return binding.broadcastPortWrite(this._handle, this._channel.handle, data)
+    const draining = this._drain
+    this._drain = null
+    draining.resolve()
   }
 
   _onflush() {

--- a/lib/broadcast-channel.js
+++ b/lib/broadcast-channel.js
@@ -28,30 +28,24 @@ class BroadcastPort {
     this._flush = null
     this._close = null
 
-    this._handle = binding.broadcastPortInit(this._channel.handle)
+    this._handle = binding.broadcastPortInit(
+      this._channel.handle,
+      this,
+      this._ondrain,
+      this._onflush,
+      this._onclose
+    )
   }
 
   async read() {
     while (this._flush !== null) await this._flush.promise
 
-    this._flush = Promise.withResolvers()
-
     while (true) {
-      if (this._queue.length > 0) {
-        this._onflush()
+      if (this._queue.length > 0) return this._queue.shift()
 
-        return this._queue.shift()
-      }
+      this._flush = Promise.withResolvers()
 
-      await new Promise((resolve) => setTimeout(resolve))
-
-      while (this._queue.length < this._queue.capacity) {
-        const data = binding.broadcastPortRead(this._handle)
-
-        if (data === null) break
-
-        this._queue.push(decode(this._channel, data))
-      }
+      await this._flush.promise
     }
   }
 
@@ -60,20 +54,16 @@ class BroadcastPort {
 
     while (this._drain !== null) await this._drain.promise
 
-    this._drain = Promise.withResolvers()
-
     const data = encode(this._channel, value, opts)
 
     while (true) {
       const flushed = binding.broadcastPortWrite(this._handle, data)
 
-      if (flushed) {
-        this._ondrain()
+      if (flushed) return true
 
-        return true
-      }
+      this._drain = Promise.withResolvers()
 
-      await new Promise((resolve) => setTimeout(resolve))
+      await this._drain.promise
     }
   }
 
@@ -86,7 +76,7 @@ class BroadcastPort {
 
     binding.broadcastPortClose(this._handle)
 
-    this._close.resolve()
+    await this._close.promise
   }
 
   _ondrain() {
@@ -98,10 +88,24 @@ class BroadcastPort {
   }
 
   _onflush() {
+    while (this._queue.length < this._queue.capacity) {
+      const data = binding.broadcastPortRead(this._handle)
+
+      if (data === null) break
+
+      this._queue.push(decode(this._channel, data))
+    }
+
     if (this._flush === null) return
 
     const flushing = this._flush
     this._flush = null
     flushing.resolve()
+  }
+
+  _onclose() {
+    if (this._close === null) this._close = Promise.withResolvers()
+
+    this._close.resolve()
   }
 }

--- a/lib/broadcast-channel.js
+++ b/lib/broadcast-channel.js
@@ -28,7 +28,7 @@ class BroadcastPort {
     this._flush = null
     this._close = null
 
-    this._id = binding.broadcastPortInit(this._channel.handle)
+    this._handle = binding.broadcastPortInit(this._channel.handle)
   }
 
   async read() {
@@ -46,7 +46,7 @@ class BroadcastPort {
       await new Promise((resolve) => setTimeout(resolve))
 
       while (this._queue.length < this._queue.capacity) {
-        const data = binding.broadcastPortRead(this._channel.handle, this._id)
+        const data = binding.broadcastPortRead(this._handle)
 
         if (data === null) break
 
@@ -65,7 +65,7 @@ class BroadcastPort {
     const data = encode(this._channel, value, opts)
 
     while (true) {
-      const flushed = binding.broadcastPortWrite(this._channel.handle, this._id, data)
+      const flushed = binding.broadcastPortWrite(this._handle, data)
 
       if (flushed) {
         this._ondrain()
@@ -84,7 +84,7 @@ class BroadcastPort {
 
     this._close = Promise.withResolvers()
 
-    binding.broadcastPortClose(this._channel.handle, this._id)
+    binding.broadcastPortClose(this._handle)
 
     this._close.resolve()
   }

--- a/lib/broadcast-channel.js
+++ b/lib/broadcast-channel.js
@@ -1,4 +1,5 @@
 const binding = require('../binding')
+const Queue = require('./queue')
 const { encode, decode } = require('./encode-decode')
 
 module.exports = class BroadcastChannel {
@@ -21,21 +22,48 @@ module.exports = class BroadcastChannel {
 class BroadcastPort {
   constructor(channel) {
     this._channel = channel
+    this._queue = new Queue()
+
+    this._flush = null
 
     this._handle = binding.broadcastPortInit(channel.handle)
   }
 
-  read() {
-    const data = binding.broadcastPortRead(this._handle, this._channel.handle)
+  async read() {
+    while (this._flush !== null) await this._flush.promise
 
-    if (data == null) return null
+    this._flush = Promise.withResolvers()
 
-    return decode(this._channel, data)
+    while (true) {
+      if (this._queue.length > 0) {
+        this._onflush()
+
+        return this._queue.shift()
+      }
+
+      while (this._queue.length < this._queue.capacity) {
+        const data = binding.broadcastPortRead(this._handle, this._channel.handle)
+
+        if (data === null) break
+
+        this._queue.push(decode(this._channel, data))
+      }
+
+      await new Promise((resolve) => setTimeout(resolve))
+    }
   }
 
   write(value, opts = {}) {
     const data = encode(this._channel, value, opts)
 
     return binding.broadcastPortWrite(this._handle, this._channel.handle, data)
+  }
+
+  _onflush() {
+    if (this._flush === null) return
+
+    const flushing = this._flush
+    this._flush = null
+    flushing.resolve()
   }
 }

--- a/lib/broadcast-channel.js
+++ b/lib/broadcast-channel.js
@@ -20,8 +20,6 @@ module.exports = class BroadcastChannel {
 }
 
 class BroadcastPort {
-  static _ports = new Set()
-
   constructor(channel) {
     this._channel = channel
     this._queue = new Queue()
@@ -31,8 +29,6 @@ class BroadcastPort {
     this._close = null
 
     this._id = binding.broadcastPortInit(this._channel.handle)
-
-    BroadcastPort._ports.add(this)
   }
 
   async read() {
@@ -90,8 +86,6 @@ class BroadcastPort {
 
     binding.broadcastPortClose(this._channel.handle, this._id)
 
-    BroadcastPort._ports.delete(this)
-
     this._close.resolve()
   }
 
@@ -111,9 +105,3 @@ class BroadcastPort {
     flushing.resolve()
   }
 }
-
-Bare.on('exit', () => {
-  for (const port of BroadcastPort._ports) {
-    port.close()
-  }
-})

--- a/lib/encode-decode.js
+++ b/lib/encode-decode.js
@@ -1,0 +1,27 @@
+const structuredClone = require('bare-structured-clone')
+
+exports.encode = function encode(channel, value, opts) {
+  const serialized = structuredClone.serializeWithTransfer(value, opts.transfer, channel.interfaces)
+
+  const state = { start: 0, end: 0, buffer: null }
+
+  structuredClone.preencode(state, serialized)
+
+  const data = new ArrayBuffer(state.end)
+
+  state.buffer = Buffer.from(data)
+
+  structuredClone.encode(state, serialized)
+
+  return data
+}
+
+exports.decode = function decode(channel, data) {
+  const state = {
+    start: 0,
+    end: data.byteLength,
+    buffer: Buffer.from(data)
+  }
+
+  return structuredClone.deserializeWithTransfer(structuredClone.decode(state), channel.interfaces)
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "brittle": "^3.1.1",
     "cmake-bare": "^1.1.7",
+    "cmake-fetch": "^1.5.1",
     "prettier": "^3.4.1",
     "prettier-config-holepunch": "^2.0.0"
   }

--- a/test.js
+++ b/test.js
@@ -495,6 +495,8 @@ test('broadcast channel', async (t) => {
     const port = broadcast.connect()
 
     await port.write('foo')
+
+    await port.close()
   })
 
   const thread2 = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
@@ -505,6 +507,8 @@ test('broadcast channel', async (t) => {
     const port = broadcast.connect()
 
     await port.write('bar')
+
+    await port.close()
   })
 
   const thread3 = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
@@ -515,6 +519,8 @@ test('broadcast channel', async (t) => {
     const port = broadcast.connect()
 
     await port.write('baz')
+
+    await port.close()
   })
 
   const port = broadcast.connect()
@@ -549,6 +555,8 @@ test('broadcast channel, buffer recycling', async (t) => {
     await port.write(2)
     await port.read()
     await port.write(3)
+
+    await port.close()
   })
 
   const thread2 = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
@@ -562,6 +570,8 @@ test('broadcast channel, buffer recycling', async (t) => {
     await port.write(5)
     await port.read()
     await port.write(6)
+
+    await port.close()
   })
 
   const thread3 = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
@@ -575,6 +585,8 @@ test('broadcast channel, buffer recycling', async (t) => {
     await port.write(8)
     await port.read()
     await port.write(9)
+
+    await port.close()
   })
 
   const port = broadcast.connect()
@@ -612,6 +624,8 @@ test('broadcast channel, ports should not read their own messages', async (t) =>
     const port = broadcast.connect()
 
     await port.write('hello from new thread')
+
+    await port.close()
   })
 
   t.is(await port.read(), 'hello from new thread')

--- a/test.js
+++ b/test.js
@@ -526,13 +526,15 @@ test('broadcast channel', async (t) => {
     if (expected.length === 0) break
   }
 
+  await port.close()
+
   thread1.join()
   thread2.join()
   thread3.join()
 })
 
-test('broadcast channel, ring rotation', async (t) => {
-  t.plan(1)
+test('broadcast channel, buffer recycling', async (t) => {
+  t.plan(9)
 
   const broadcast = new BroadcastChannel()
 
@@ -581,12 +583,12 @@ test('broadcast channel, ring rotation', async (t) => {
   while (true) {
     count++
 
-    t.comment(await port.read())
+    t.is(await port.read(), count)
 
     if (count === 9) break
   }
 
-  t.pass()
+  await port.close()
 
   thread1.join()
   thread2.join()

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 const test = require('brittle')
 const { symbols } = require('bare-structured-clone')
 const Channel = require('.')
+const BroadcastChannel = require('./lib/broadcast-channel')
 const { Thread } = Bare
 
 test('basic', async (t) => {
@@ -479,4 +480,52 @@ test('both sides unref in same thread', async (t) => {
   })
 
   thread.join()
+})
+
+test('broadcast channel', async (t) => {
+  t.plan(3)
+
+  const broadcast = new BroadcastChannel()
+
+  const thread1 = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
+    const BroadcastChannel = require('./lib/broadcast-channel')
+
+    const broadcast = BroadcastChannel.from(handle)
+
+    const port = broadcast.connect()
+
+    port.write('foo')
+  })
+
+  const thread2 = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
+    const BroadcastChannel = require('./lib/broadcast-channel')
+
+    const broadcast = BroadcastChannel.from(handle)
+
+    const port = broadcast.connect()
+
+    port.write('bar')
+  })
+
+  const thread3 = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
+    const BroadcastChannel = require('./lib/broadcast-channel')
+
+    const broadcast = BroadcastChannel.from(handle)
+
+    const port = broadcast.connect()
+
+    port.write('baz')
+  })
+
+  const port = broadcast.connect()
+
+  setTimeout(() => {
+    t.is(port.read(), 'foo')
+    t.is(port.read(), 'bar')
+    t.is(port.read(), 'baz')
+  })
+
+  thread1.join()
+  thread2.join()
+  thread3.join()
 })

--- a/test.js
+++ b/test.js
@@ -494,7 +494,7 @@ test('broadcast channel', async (t) => {
 
     const port = broadcast.connect()
 
-    port.write('foo')
+    await port.write('foo')
   })
 
   const thread2 = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
@@ -504,7 +504,7 @@ test('broadcast channel', async (t) => {
 
     const port = broadcast.connect()
 
-    port.write('bar')
+    await port.write('bar')
   })
 
   const thread3 = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
@@ -514,7 +514,7 @@ test('broadcast channel', async (t) => {
 
     const port = broadcast.connect()
 
-    port.write('baz')
+    await port.write('baz')
   })
 
   const port = broadcast.connect()

--- a/test.js
+++ b/test.js
@@ -482,7 +482,7 @@ test('both sides unref in same thread', async (t) => {
   thread.join()
 })
 
-test('broadcast channel', async (t) => {
+test.solo('broadcast channel', async (t) => {
   t.plan(3)
 
   const broadcast = new BroadcastChannel()

--- a/test.js
+++ b/test.js
@@ -519,11 +519,12 @@ test('broadcast channel', async (t) => {
 
   const port = broadcast.connect()
 
-  setTimeout(() => {
-    t.is(port.read(), 'foo')
-    t.is(port.read(), 'bar')
-    t.is(port.read(), 'baz')
-  })
+  const expected = ['foo', 'bar', 'baz']
+
+  while (true) {
+    t.alike(await port.read(), expected.shift())
+    if (expected.length === 0) break
+  }
 
   thread1.join()
   thread2.join()

--- a/test.js
+++ b/test.js
@@ -534,7 +534,7 @@ test('broadcast channel', async (t) => {
 })
 
 test('broadcast channel, buffer recycling', async (t) => {
-  t.plan(9)
+  t.plan(1)
 
   const broadcast = new BroadcastChannel()
 
@@ -579,18 +579,44 @@ test('broadcast channel, buffer recycling', async (t) => {
 
   const port = broadcast.connect()
 
-  let count = 0
+  let count = 1
   while (true) {
-    count++
+    await port.read()
 
-    t.is(await port.read(), count)
-
-    if (count === 9) break
+    if (count++ === 9) break
   }
+
+  t.pass()
 
   await port.close()
 
   thread1.join()
   thread2.join()
   thread3.join()
+})
+
+test('broadcast channel, ports should not read their own messages', async (t) => {
+  t.plan(1)
+
+  const broadcast = new BroadcastChannel()
+
+  const port = broadcast.connect()
+
+  await port.write('hello from main thread')
+
+  const thread = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
+    const BroadcastChannel = require('./lib/broadcast-channel')
+
+    const broadcast = BroadcastChannel.from(handle)
+
+    const port = broadcast.connect()
+
+    await port.write('hello from new thread')
+  })
+
+  t.is(await port.read(), 'hello from new thread')
+
+  await port.close()
+
+  thread.join()
 })

--- a/test.js
+++ b/test.js
@@ -525,80 +525,17 @@ test('broadcast channel', async (t) => {
 
   const port = broadcast.connect()
 
-  const expected = ['foo', 'bar', 'baz']
+  let expected = ['foo', 'bar', 'baz']
 
   while (true) {
-    t.alike(await port.read(), expected.shift())
+    const value = await port.read()
+
+    t.ok(expected.includes(value))
+
+    expected = expected.filter((item) => item !== value)
+
     if (expected.length === 0) break
   }
-
-  await port.close()
-
-  thread1.join()
-  thread2.join()
-  thread3.join()
-})
-
-test('broadcast channel, buffer recycling', async (t) => {
-  t.plan(1)
-
-  const broadcast = new BroadcastChannel()
-
-  const thread1 = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
-    const BroadcastChannel = require('./lib/broadcast-channel')
-
-    const broadcast = BroadcastChannel.from(handle)
-
-    const port = broadcast.connect()
-
-    await port.write(1)
-    await port.write(2)
-    await port.read()
-    await port.write(3)
-
-    await port.close()
-  })
-
-  const thread2 = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
-    const BroadcastChannel = require('./lib/broadcast-channel')
-
-    const broadcast = BroadcastChannel.from(handle)
-
-    const port = broadcast.connect()
-
-    await port.write(4)
-    await port.write(5)
-    await port.read()
-    await port.write(6)
-
-    await port.close()
-  })
-
-  const thread3 = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
-    const BroadcastChannel = require('./lib/broadcast-channel')
-
-    const broadcast = BroadcastChannel.from(handle)
-
-    const port = broadcast.connect()
-
-    await port.write(7)
-    await port.write(8)
-    await port.read()
-    await port.write(9)
-
-    await port.close()
-  })
-
-  const port = broadcast.connect()
-
-  let count = 1
-  while (true) {
-    await port.read()
-
-    if (count++ === 9) break
-  }
-
-  t.pass()
 
   await port.close()
 
@@ -629,6 +566,49 @@ test('broadcast channel, ports should not read their own messages', async (t) =>
   })
 
   t.is(await port.read(), 'hello from new thread')
+
+  await port.close()
+
+  thread.join()
+})
+
+test('broadcast channel, buffer rotation', async (t) => {
+  t.plan(1)
+
+  const broadcast = new BroadcastChannel()
+
+  const thread = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
+    const BroadcastChannel = require('./lib/broadcast-channel')
+
+    const broadcast = BroadcastChannel.from(handle)
+
+    const port = broadcast.connect()
+
+    let count = 0
+
+    while (true) {
+      await port.write(++count)
+      await port.read()
+
+      if (count === 10) break
+    }
+
+    await port.close()
+  })
+
+  const port = broadcast.connect()
+
+  let loopCount = 0
+
+  while (true) {
+    await port.write('foo')
+    await port.read()
+
+    if (++loopCount === 9) break
+  }
+
+  await port.write('foo')
+  t.is(await port.read(), 10)
 
   await port.close()
 

--- a/test.js
+++ b/test.js
@@ -530,3 +530,65 @@ test('broadcast channel', async (t) => {
   thread2.join()
   thread3.join()
 })
+
+test('broadcast channel, ring rotation', async (t) => {
+  t.plan(1)
+
+  const broadcast = new BroadcastChannel()
+
+  const thread1 = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
+    const BroadcastChannel = require('./lib/broadcast-channel')
+
+    const broadcast = BroadcastChannel.from(handle)
+
+    const port = broadcast.connect()
+
+    await port.write(1)
+    await port.write(2)
+    await port.read()
+    await port.write(3)
+  })
+
+  const thread2 = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
+    const BroadcastChannel = require('./lib/broadcast-channel')
+
+    const broadcast = BroadcastChannel.from(handle)
+
+    const port = broadcast.connect()
+
+    await port.write(4)
+    await port.write(5)
+    await port.read()
+    await port.write(6)
+  })
+
+  const thread3 = new Thread(__filename, { data: broadcast.handle }, async (handle) => {
+    const BroadcastChannel = require('./lib/broadcast-channel')
+
+    const broadcast = BroadcastChannel.from(handle)
+
+    const port = broadcast.connect()
+
+    await port.write(7)
+    await port.write(8)
+    await port.read()
+    await port.write(9)
+  })
+
+  const port = broadcast.connect()
+
+  let count = 0
+  while (true) {
+    count++
+
+    t.comment(await port.read())
+
+    if (count === 9) break
+  }
+
+  t.pass()
+
+  thread1.join()
+  thread2.join()
+  thread3.join()
+})


### PR DESCRIPTION
MPMC based on: https://web.archive.org/web/20250830190104/http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue

---

~async and blocking-wise operations are yet to be done.~

I intend to use `intrusive/list` to keep record of the active ports; ~The logic to reuse buffer slots is also yet to be done.~ ~My current idea is to, whenever the queue gets full, release slots based on the value of the smallest `tail_cursor` from the active ports set, if possible.~

`BARE_CHANNEL_BROADCAST_RING_CAPACITY` has a short value for now to facilitate the ring rotation tests.

---

~Edit: The idea using described above `intrusive/list` was implemented, the broadcast channel has a `tail_cursor` value that is updated at the `bare_channel_broadcast__recycle_queue` method, each port has an individual `tail_cursor`.~

~`bare_channel_broadcast_port_t` is constructed with `malloc` to play nicely with `intrusive/list` operations.~

---

Edit 2:

~I tried using `js_deferred_teardown_t` when working on the "Add BroadcastPort.close() method" but I ended with a manual teardown flow for now.~